### PR TITLE
[docker] Test env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file[^1].
 ## [Unreleased]
 ### Added
 - map all datings in item harvester
+- docker test runner
 
 ### Added
 - Improved reproduction images and enabled ReproductionsPage in NavBar

--- a/README.md
+++ b/README.md
@@ -98,10 +98,18 @@ variants by editing that variable.
 	```
 	docker-compose exec php php artisan es:setup
 	```  
-7. visit http://localhost:8080 in your browser to have a look  
+7. visit http://localhost:8080 in your browser to have a look
 
-to stop the dockerized application: `docker-compose down`  
+    to stop the dockerized application: `docker-compose down`
 
+8. run all tests
+    ```
+    ./test.sh
+    ```
+   or with command line options (see: <https://devdocs.io/phpunit~4/textui>)
+    ```
+    ./test.sh --filter ViewTest
+    ```
 
 ## Harvesting Data
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.2'
 services:
   web:
     image: nginx:latest

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,1 @@
+docker-compose up -d && docker-compose exec $(sed -e 's/^/-e /' .env.testing) php ./vendor/bin/phpunit "$@"


### PR DESCRIPTION
I had to update compose file format version to 2.2 because we want to set env vars for tests, but they are already set for container and cannot be easily changed. This may be fixed in future by upgrading to PHPUnit>=6.3 (requires PHP>=7) where we can force env vars in `phpunit.xml` config https://github.com/sebastianbergmann/phpunit/pull/2723 or by creating whole new test environment with separated containers.

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have updated the [CHANGELOG](../CHANGELOG.md)
- [x] I have requested at least 1 reviewer for this PR
- [x] I have made corresponding changes to the documentation
