### PR TITLE
[harvest] Don't create relations to non-existing entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file[^1].
 ## [Unreleased]
 ### Fixed
 - add panorama image dir to deployer config
+- duplicated authors in item detail
+
+### Changed
+- disallow importing of relations to non-existing entities
 
 ## [2.4.0] - 2020-04-01
 ### Added

--- a/tests/Harvest/Importers/AuthorityImporterTest.php
+++ b/tests/Harvest/Importers/AuthorityImporterTest.php
@@ -43,18 +43,9 @@ class AuthorityImporterTest extends TestCase
         $row = $this->getData();
         $importer = $this->initImporter($row);
 
-        $importer->import($row, $result = new Result());
-
-        $links = Link::all();
-        $this->assertEquals(1, $links->count());
-        $this->assertEquals('example.org', $links->first()->label);
-    }
-
-    public function testInsertRelated() {
-        $row = $this->getData();
-        $importer = $this->initImporter($row);
-
-        $importer->import($row, $result = new Result());
+        $authority = $importer->import($row, $result = new Result());
+        $this->assertEquals(1, $authority->links->count());
+        $this->assertEquals('example.org', $authority->links[0]->label);
     }
 
     public function testExistingButNotRelatedYet() {
@@ -66,10 +57,8 @@ class AuthorityImporterTest extends TestCase
         $row = $this->getData();
         $importer = $this->initImporter($row);
 
-        $importer->import($row, $result = new Result());
-
-        $item = Authority::first();
-        $this->assertCount(1, $item->nationalities);
+        $authority = $importer->import($row, $result = new Result());
+        $this->assertEquals(1, $authority->nationalities->count());
     }
 
     public function testRelatedButNotExisting() {
@@ -82,7 +71,8 @@ class AuthorityImporterTest extends TestCase
         $row = $this->getData();
         $importer = $this->initImporter($row);
 
-        $importer->import($row, $result = new Result());
+        $authority = $importer->import($row, $result = new Result());
+        $this->assertEquals(0, $authority->relationships->count());
     }
 
     protected function getData() {
@@ -211,7 +201,6 @@ class AuthorityImporterTest extends TestCase
                 ['prefered' => false]
             );
         $authorityRelationshipMapperMock
-            ->expects($this->exactly(3))
             ->method('map')
             ->withConsecutive(
                 [$row['relationships'][0]],


### PR DESCRIPTION
# Description

Till now relations were created even if the related entities didn't exist. Even if that might be handy when harvested data come before its related data, generally it's not a good practice. If we want to preserve this behavior I'd suggest creating hidden entities for later completion.

Fixes https://jira.sng.sk/browse/WEBUMENIA-1337

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have updated the [CHANGELOG](../CHANGELOG.md)
- [x] I have requested at least 1 reviewer for this PR
- [ ] I have made corresponding changes to the documentation
