### PR TITLE
bugfix//WEBUMENIA-1311: fix padding for responsive images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file[^1].
 - sort collections in admin by creation date and allow to unpublish them
 - corrected few czech localization strings 
 - article social sharing images
+- fix ratio-box padding for responsive images
 
 ## [2.5.0] - 2020-04-15
 ### Added

--- a/resources/views/components/artwork_grid_item.blade.php
+++ b/resources/views/components/artwork_grid_item.blade.php
@@ -1,13 +1,7 @@
 <div class="{{$isotope_item_selector_class ?? 'item'}} {{$class_names ?? ''}}">
-    <a href="{!! $item->getUrl() !!}">
-        @php
-            list($width, $height) = getimagesize(public_path() . $item->getImagePath());
-            $width =  max($width,1); // prevent division by zero exception
-        @endphp
-        <div class="ratio-box" style="padding-bottom: {{ round(($height / $width) * 100, 4) }}%;">
-             @include('components.item_image_responsive', ['item' => $item, 'width' => $width, 'height' => $height ])
-        </div>
-    </a>
+    
+    @include('components.item_image_responsive', ['item' => $item, 'limitRatio' => 3])
+    
     <div class="item-title">
         @if( !isset($hide_zoom) )
             @if ($item->has_iip)

--- a/resources/views/components/item_image_responsive.blade.php
+++ b/resources/views/components/item_image_responsive.blade.php
@@ -1,11 +1,49 @@
-<img
-    data-sizes="auto"
-    data-src="{!! route('dielo.nahlad', ['id' => $item->id, 'width'=>'600']) !!}"
-    data-srcset="{!! route('dielo.nahlad', ['id' => $item->id, 'width'=>'600']) !!} 600w,
-            {!! route('dielo.nahlad', ['id' => $item->id, 'width'=>'220']) !!} 220w,
-            {!! route('dielo.nahlad', ['id' => $item->id, 'width'=>'300']) !!} 300w,
-            {!! route('dielo.nahlad', ['id' => $item->id, 'width'=>'600']) !!} 600w,
-            {!! route('dielo.nahlad', ['id' => $item->id, 'width'=>'800']) !!} 800w"
-    class="lazyload"
-    style="{!! isset($width) ? 'max-width:'.$width.'px;': '' !!} {!! isset($height) ? 'max-height:'.$height.'px;' : '' !!}"
-    alt="{!! $item->getTitleWithAuthors() !!} "/>
+@php
+    list($width, $height) = getimagesize(public_path() . $item->getImagePath());
+    $width = max($width,1); // prevent division by zero exception
+    $ratio = round(($height / $width) , 4);
+    if (isset($limitRatio)){
+        $ratio = min($limitRatio, $ratio);
+    }
+@endphp
+
+<!-- limitHeight is used to set maximum container height, good for large images (e.g. artwork) -->
+@if (isset($limitHeight))
+
+  <div style="text-align:center;width: 100%;{{isset($limitHeight) ? 'max-height:'.$limitHeight : ''}}">
+      <div style="margin: auto; {!! 'max-width:'.$width.'px;' !!} {!! isset($height) ? 'max-height:'.$height.'px;' : '' !!}">
+          <a href="{!! isset($url) ? $url : $item->getUrl() !!}">
+              <div style="width: 100%; height: 100%">
+                  <img data-sizes="auto" data-src="{!! route('dielo.nahlad', ['id' => $item->id, 'width'=>'600']) !!}"
+                      data-srcset="{!! route('dielo.nahlad', ['id' => $item->id, 'width'=>'600']) !!} 600w,
+                      {!! route('dielo.nahlad', ['id' => $item->id, 'width'=>'220']) !!} 220w,
+                      {!! route('dielo.nahlad', ['id' => $item->id, 'width'=>'300']) !!} 300w,
+                      {!! route('dielo.nahlad', ['id' => $item->id, 'width'=>'600']) !!} 600w,
+                      {!! route('dielo.nahlad', ['id' => $item->id, 'width'=>'800']) !!} 800w" class="lazyload"
+                      style="object-fit:contain; width:100%; max-height:{!! $limitHeight !!}"
+                      alt="{!! $item->getTitleWithAuthors() !!} " />
+              </div>
+          </a>
+      </div>
+  </div>
+
+@else
+
+<!-- otherwise we stick to container width and maximum aloved ratio, good for narrow containers (e.g. preview columns) -->
+  <div style="text-align:center;width: 100%;">
+      <div style="margin: auto; {!! 'max-width:'.$width.'px;' !!} {!! isset($height) ? 'max-height:'.$height.'px;' : '' !!}">
+          <a href="{!! isset($url) ? $url : $item->getUrl() !!}">
+              <div class="ratio-box" style="padding-bottom: {{ round(($ratio) * 100, 4) }}%;">
+                  <img data-sizes="auto" data-src="{!! route('dielo.nahlad', ['id' => $item->id, 'width'=>'600']) !!}"
+                      data-srcset="{!! route('dielo.nahlad', ['id' => $item->id, 'width'=>'600']) !!} 600w,
+                      {!! route('dielo.nahlad', ['id' => $item->id, 'width'=>'220']) !!} 220w,
+                      {!! route('dielo.nahlad', ['id' => $item->id, 'width'=>'300']) !!} 300w,
+                      {!! route('dielo.nahlad', ['id' => $item->id, 'width'=>'600']) !!} 600w,
+                      {!! route('dielo.nahlad', ['id' => $item->id, 'width'=>'800']) !!} 800w" class="lazyload"
+                      style="object-fit:contain" alt="{!! $item->getTitleWithAuthors() !!} " />
+              </div>
+          </a>
+      </div>
+  </div>
+
+@endif

--- a/resources/views/components/item_image_responsive.json
+++ b/resources/views/components/item_image_responsive.json
@@ -3,6 +3,8 @@
     "data_calls" : {
       "item": "use App\\ItemImage; return $sample_item = ItemImage::inRandomOrder()->whereNotNull('iipimg_url')->first()->item;"
     },
-    "data": {},
-    "usage_notes": "Generates markup for responsive <img> with automatic sizes calculation for model Item. Requires lazysizes.js"
+    "data": {
+      "limitHeight" : "40vh"
+    },
+    "usage_notes": "Generates markup for responsive <img> with automatic sizes calculation for model Item. Requires lazysizes.js. Use limitHeight for big containers, limitRatio for narrow ones"
 }

--- a/resources/views/dielo.blade.php
+++ b/resources/views/dielo.blade.php
@@ -76,14 +76,10 @@
                     @php
                     list($width, $height) = getimagesize(public_path() . $item->getImagePath());
                     @endphp
-                    <div class="ratio-box bottom-space"
-                        style="padding-bottom: {{ round(($height / $width) * 100, 4) }}%; padding-bottom: min({{ round(($height / $width) * 100, 4) }}% , {{$height  + 30}}px)">
                         @include('components.item_image_responsive', [
-                            'item' => $item,
-                            'width' => $width,
-                            'height' => $height
-                        ])
-                    </div>
+                            'item' => $item ,
+                            'limitHeight' => '80vh'
+                            ])
                     @endif
                     <div class="row mt-5">
                         <div class="col-sm-12">

--- a/resources/views/frontend/catalog/index.blade.php
+++ b/resources/views/frontend/catalog/index.blade.php
@@ -54,15 +54,9 @@
                     <div id="iso">
                         @foreach ($paginator as $item)
                             <div class="col-md-3 col-sm-4 col-xs-6 item">
-                                <a href="{!! $item->getUrl() !!}">
-                                    @php
-                                        list($width, $height) = getimagesize(public_path() . $item->getImagePath());
-                                        $width =  max($width,1); // prevent division by zero exception
-                                    @endphp
-                                    <div class="ratio-box" style="padding-bottom: {{ round(($height / $width) * 100, 4) }}%;">
-                                        @include('components.item_image_responsive', ['item' => $item])
-                                    </div>
-                                </a>
+                                
+                                @include('components.item_image_responsive', ['item' => $item , 'limitRatio' => 3])
+                                
                                 <div class="item-title">
                                     @if ($item->has_iip)
                                         <div class="pull-right"><a href="{{ route('item.zoom', ['id' => $item->id]) }}" data-toggle="tooltip" data-placement="left" title="{{ utrans('general.item_zoom') }}"><i class="fa fa-search-plus"></i></a></div>

--- a/resources/views/kolekcia.blade.php
+++ b/resources/views/kolekcia.blade.php
@@ -96,24 +96,11 @@
                     <div id="iso">
                     @foreach ($collection->items as $i=>$item)
                         <div class="col-md-3 col-sm-4 col-xs-12 item">
-                            <a href="{!! $item->getUrl(['collection' => $collection->id]) !!}">
-                                @php
-                                    list($width, $height) = getimagesize(public_path() . $item->getImagePath());
-                                    $width =  max($width,1); // prevent division by zero exception
-                                @endphp
-                                <div class="ratio-box" style="padding-bottom: {{ round(($height / $width) * 100, 4) }}%;">
-
-                                <img
-                                    data-sizes="auto"
-                                    data-src="{!! route('dielo.nahlad', ['id' => $item->id, 'width'=>'600']) !!}"
-                                    data-srcset="{!! route('dielo.nahlad', ['id' => $item->id, 'width'=>'600']) !!} 600w,
-                                            {!! route('dielo.nahlad', ['id' => $item->id, 'width'=>'220']) !!} 220w,
-                                            {!! route('dielo.nahlad', ['id' => $item->id, 'width'=>'300']) !!} 300w,
-                                            {!! route('dielo.nahlad', ['id' => $item->id, 'width'=>'600']) !!} 600w,
-                                            {!! route('dielo.nahlad', ['id' => $item->id, 'width'=>'800']) !!} 800w"
-                                    class="lazyload"
-                                    alt="{!! $item->getTitleWithAuthors() !!} ">
-                                </div>
+                                @include('components.item_image_responsive', [
+                                    'item' => $item,
+                                    'url' => $item->getUrl(['collection' => $collection->id]) , 
+                                    'limitRatio' => 3
+                                ])
                             </a>
                             <div class="item-title">
                                 @if (!$item->images->isEmpty())


### PR DESCRIPTION
# Description

just another attempt to fix odd padding-bottom for super tall images, looked okay on safari/chrome/FF/opera, IE would have problem with object-fit (does anyone cares still? )

Fixes # (link to Jira or GitHub issue)
https://jira.sng.sk/browse/WEBUMENIA-1311

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have updated the [CHANGELOG](../CHANGELOG.md)
- [x] I have requested at least 1 reviewer for this PR
- [ ] I have made corresponding changes to the documentation
