### PR TITLE
add migration to make note nullable in orders table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file[^1].
 
 ## [Unreleased]
+
+## [2.6.2] - 2020-05-11
 ### Fixed
 - creating order with empty note
 
@@ -436,6 +438,7 @@ All notable changes to this project will be documented in this file[^1].
 - LICENSE from Public Domain into MIT
 
 [Unreleased]: https://github.com/SlovakNationalGallery/web-umenia-2/compare/master...develop
+[2.6.2]: https://github.com/SlovakNationalGallery/webumenia.sk/pull/319
 [2.6.1]: https://github.com/SlovakNationalGallery/webumenia.sk/pull/314
 [2.6.0]: https://github.com/SlovakNationalGallery/webumenia.sk/pull/313
 [2.5.0]: https://github.com/SlovakNationalGallery/webumenia.sk/pull/305

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file[^1].
 
 ## [Unreleased]
+### Fixed
+- creating order with empty note
 
 ## [2.6.1] - 2020-05-04
 ### Fixed
@@ -17,7 +19,7 @@ All notable changes to this project will be documented in this file[^1].
 
 ### Fixed
 - sort collections in admin by creation date and allow to unpublish them
-- corrected few czech localization strings 
+- corrected few czech localization strings
 - article social sharing images
 - fix ratio-box padding for responsive images
 - unmap item description in harvester

--- a/database/migrations/2020_05_11_140625_make_note_nullable_in_orders_table.php
+++ b/database/migrations/2020_05_11_140625_make_note_nullable_in_orders_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class MakeNoteNullableInOrdersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            $table->text('note')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            $table->text('note')->change();
+        });
+    }
+}


### PR DESCRIPTION
# Description

add migration to make note nullable in orders table

Fixes [WEBUMENIA-1371](https://jira.sng.sk/browse/WEBUMENIA-1371)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have updated the [CHANGELOG](../CHANGELOG.md)
- [x] I have requested at least 1 reviewer for this PR
- [ ] I have made corresponding changes to the documentation
