### PR TITLE
Hotfix/webumenia 1410 covid update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file[^1].
 
 ## [Unreleased]
 
+## [2.7.2] - 2020-07-02
+### Changed
+- COVID-19 alert for printed reproductions
+- temporarily disable loading preview image from IIP in artwork detail
+
 ## [2.7.1] - 2020-05-28
 ### Fixed
 - mapping of item identifier in harvester
@@ -18,7 +23,7 @@ All notable changes to this project will be documented in this file[^1].
 - search of unlisted place in authority filter
 - missing medium, related work item filters
 - overwriting authority's attributes in item harvester
-- indexing of item's work types 
+- indexing of item's work types
 
 ### Changed
 - COVID-19 alert for printed reproductions

--- a/resources/lang/en/reprodukcie.php
+++ b/resources/lang/en/reprodukcie.php
@@ -54,6 +54,7 @@ return array(
                             </ul>',
     'digital_choice'    => 'Choose your reproductions',
     'more-items_button' => 'Show all',
-    'alert_covid-19' => 'We are reopened. You can pick up your reproductions within the open hours (please follow the COVID-19 guidelines and recommendations). ',
+    'alert_covid-19' => 'We\'re open again. You can pick up the reproductions at the <a href="https://www.sng.sk/sk/bratislava/navsteva/otvaracie-hodiny-a-vstupne" target="_blank">Ex Libris bookstore</a> and <a href="https://www.sng.sk/sk/zvolen/navsteva/otvaracie-hodiny-a-vstupne" target="_blank">Zvolen Castle</a> during the standard opening hours. When picking up your reproduction order, please follow the measures of individual and collective protection against the spread of coronavirus and COVID-19 disease. <br>
+    Due to the current situation, it will take more than 30 days to prepare and deliver the orders. <br>Thank you for you patience. We are looking forward to seeing you again soon!',
 
 );

--- a/resources/lang/en/reprodukcie.php
+++ b/resources/lang/en/reprodukcie.php
@@ -54,6 +54,6 @@ return array(
                             </ul>',
     'digital_choice'    => 'Choose your reproductions',
     'more-items_button' => 'Show all',
-    'alert_covid-19' => ' Due to the preventive measures against the spread of Coronavirus COVID-19, the reproduction pickup locations (Ex Libris Bookstore in Bratislava and SNG Zvolen castle) are closed until further notice. Thank you for understanding.',
+    'alert_covid-19' => 'We are reopened. You can pick up your reproductions within the open hours (please follow the COVID-19 guidelines and recommendations). ',
 
 );

--- a/resources/lang/sk/reprodukcie.php
+++ b/resources/lang/sk/reprodukcie.php
@@ -54,9 +54,7 @@ return array(
     'digital_choice'    => 'Vyberte si reprodukcie',
     'more-items_button' => 'zobraziť všetky',
 
-    'alert_covid-19' => 'Čoskoro bude opäť možné vyzdvihnúť si tlačené reprodukcie v kníhkupectve Ex Libris, budeme Vás informovať o presnom dátume. Zvolenský zámok je už otvorený a reprodukcie si môžete vyzdvihnúť v <a href="https://www.sng.sk/sk/zvolen/navsteva/otvaracie-hodiny-a-vstupne" target="_blank">pracovné dni</a>. <br>
-    Pri preberaní objednávok prosíme o dodržiavanie platných opatrení individuálnej a kolektívnej ochrany a prevencie voči šíreniu ochorenia COVID-19.<br>
-Vzhľadom na doterajšiu situáciu bude vybavenie objednávky trvať dlhšie ako 30 dní.<br>
-Ďakujeme za trpezlivosť a tešíme sa na Vašu návštevu.',
+    'alert_covid-19' => 'Sme opäť otvorení. Pripravené reprodukcie si môžete vyzdvihnúť v <a href="https://www.sng.sk/sk/bratislava/navsteva/otvaracie-hodiny-a-vstupne" target="_blank">kníhkupectve Ex Libris</a>, resp. <a href="https://www.sng.sk/sk/zvolen/navsteva/otvaracie-hodiny-a-vstupne" target="_blank">Zvolenskom zámku</a> počas štandardných otváracích hodín. Pri preberaní objednávok prosíme o dodržiavanie aktuálnych opatrení individuálnej a kolektívnej ochrany v súvislosti s prevenciou voči šíreniu ochorenia COVID-19. <br>
+    Vzhľadom na doterajšiu situáciu bude vybavenie objednávky trvať dlhšie ako 30 dní.<br> Ďakujeme za trpezlivosť a tešíme sa na Vašu návštevu.',
 
 );

--- a/resources/views/dielo.blade.php
+++ b/resources/views/dielo.blade.php
@@ -53,7 +53,8 @@
             </div>
             <div class="row img-dielo">
                 <div class="col-md-8 text-center">
-                    @if ($item->has_iip)
+                    {{-- @TODO: return back after IIP is fast enoght to handle it --}}
+                    @if ($item->has_iip && false)
                     @php
                         list($width, $height) = getimagesize(public_path() . $item->getImagePath());
                     @endphp


### PR DESCRIPTION
# Description

Update COVID-19 alert for printed reproductions
Temporarily disable loading preview image from IIP in artwork detail


Fixes [WEBUMENIA-1410](https://jira.sng.sk/browse/WEBUMENIA-1410)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have updated the [CHANGELOG](../CHANGELOG.md)
- [x] I have requested at least 1 reviewer for this PR
- [ ] I have made corresponding changes to the documentation
