### PR TITLE
[filesystem] skip links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to this project will be documented in this file[^1].
 ### Fixed
 - wrong method name in harvester
 
+### Changed
+- skip links in flysystem
+
 ## [2.8.0] - 2020-10-26
 ### Added
 - color picker to patternlib

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -46,12 +46,14 @@ return [
         'local' => [
             'driver' => 'local',
             'root' => storage_path('app'),
+            'links' => 'skip',
         ],
 
         'public' => [
             'driver' => 'local',
             'root' => storage_path('app/public'),
             'visibility' => 'public',
+            'links' => 'skip',
         ],
 
         's3' => [


### PR DESCRIPTION
# Description

[Links are not supported by flysystem](https://github.com/thephpleague/flysystem/issues/599). We want to symlink images from storage to image server, but it'd fail on searching directory for csv files.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have updated the [CHANGELOG](../CHANGELOG.md)
- [x] I have requested at least 1 reviewer for this PR
- [ ] I have made corresponding changes to the documentation
