### PR TITLE
Suggestion: Run tests on GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,13 @@
+name: Test on push
+
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set .env file
+        run: cp .env.example .env
+      - name: Test
+        run: docker-compose run php bash -c "npm run testing && vendor/bin/phpunit"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-services:
-  - docker
-
-before_install:  
-  - cp .env.example .env
-
-script:
-  - docker-compose run php bash -c "npm run testing && vendor/bin/phpunit"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file[^1].
 ### Changed
 - use authority matcher in item detail
 - SGP into list of galleries in the info page
+- Run tests on GitHub Actions
 
 ## [2.13.0] - 2020-11-27
 ### Added


### PR DESCRIPTION
Travis CI have [introduced a new pricing model](https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing) and it looks like we've run out of our credits already.

Here's a suggestion to move our tests to Github Actions.

Example run: https://github.com/SlovakNationalGallery/webumenia.sk/runs/1498527472