### PR TITLE
use asset_timed for og:image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file[^1].
 
 ## [Unreleased]
+## [2.13.1] - 2020-12-07
+### Fixed
+- Use method asset_timed to avoid caching of og:image
+
 ## [2.13.0] - 2020-11-27
 ### Added
 - Add 'copy citation' button to artwork detail

--- a/app/Helpers/general.php
+++ b/app/Helpers/general.php
@@ -133,7 +133,7 @@ function asset_timed($path, $secure = null)
     if (file_exists($file)) {
         return asset($path, $secure) . '?' . filemtime($file);
     } else {
-        throw new \Exception('The file "'.$path.'" cannot be found in the public folder');
+        return asset($path, $secure); // fallback to default asset() to avoid exception
     }
 }
 

--- a/resources/views/autor.blade.php
+++ b/resources/views/autor.blade.php
@@ -5,7 +5,7 @@
 <meta property="og:description" content="{{ $description }}" />
 <meta property="og:type" content="object" />
 <meta property="og:url" content="{!! Request::url() !!}" />
-<meta property="og:image" content="{!! URL::to( $author->getImagePath() ) !!}" />
+<meta property="og:image" content="{!! asset_timed( $author->getImagePath() ) !!}" />
 <meta property="og:site_name" content="Web umenia" />
 @stop
 

--- a/resources/views/clanok.blade.php
+++ b/resources/views/clanok.blade.php
@@ -8,7 +8,7 @@
 <meta property="og:description" content="{!! strip_tags($article->summary) !!}" />
 <meta property="og:type" content="website" />
 <meta property="og:url" content="{!! Request::url() !!}" />
-<meta property="og:image" content="{!! URL::to( $article->getHeaderImage()) !!}" />
+<meta property="og:image" content="{!! asset_timed( $article->getHeaderImage()) !!}" />
 
 @foreach ($article->getContentImages() as $image )
 <meta property="og:image" content="{!! $image !!}" />

--- a/resources/views/dielo.blade.php
+++ b/resources/views/dielo.blade.php
@@ -6,7 +6,7 @@
     content="{!! $item->work_type; !!}, {{ trans('dielo.item_attr_dating') }}: {!! $item->dating !!}, {{ trans('dielo.item_attr_measurements') }}: {!!  implode(' x ', $item->measurements) !!}" />
 <meta property="og:type" content="object" />
 <meta property="og:url" content="{!! Request::url() !!}" />
-<meta property="og:image" content="{!! URL::to( $item->getImagePath() ) !!}" />
+<meta property="og:image" content="{!! asset_timed( $item->getImagePath() ) !!}" />
 <meta property="og:site_name" content="Web umenia" />
 @stop
 

--- a/resources/views/includes/og_tags.blade.php
+++ b/resources/views/includes/og_tags.blade.php
@@ -5,6 +5,6 @@
 <meta property="og:description" content="{{ trans('master.meta_description') }}" />
 <meta property="og:type" content="website" />
 <meta property="og:url" content="{!! Request::url() !!}" />
-<meta property="og:image" content="{!! URL::to('/images/og-image-'.random_int(1, 2).'.jpg') !!}" />
+<meta property="og:image" content="{!! asset('/images/og-image-'.random_int(1, 2).'.jpg') !!}" />
 <meta property="og:site_name" content="web umenia" />
 @show

--- a/resources/views/kolekcia.blade.php
+++ b/resources/views/kolekcia.blade.php
@@ -8,7 +8,7 @@
 <meta property="og:description" content="{!! $collection->getShortTextAttribute($collection->text, 500) !!}" />
 <meta property="og:type" content="website" />
 <meta property="og:url" content="{!! Request::url() !!}" />
-<meta property="og:image" content="{!! URL::to($collection->getHeaderImage()) !!}" />
+<meta property="og:image" content="{!! asset_timed($collection->getHeaderImage()) !!}" />
 <meta property="og:site_name" content="web umenia" />
 @foreach ($collection->getContentImages() as $image )
     <meta property="og:image" content="{!! $image !!}" />


### PR DESCRIPTION
# Description

This is a fix to overcome facebook caching of `og:image` ( https://stackoverflow.com/questions/7572441/facebook-like-showing-cached-version-ogimage-way-to-refresh-or-reindex-it ) - to enable new "sharing preview" after og:image is changed.

Re-using already written method `asset_timed()` to include timestamp in image path (e.g. `<meta property="og:image" content="https://www.webumenia.sk/images/clanky/psicek-a-macicka-sa-tesia.jpg?1433999652" />`)

Fixes [WEBUMENIA-1513](https://jira.sng.sk/browse/WEBUMENIA-1513)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have updated the [CHANGELOG](../CHANGELOG.md)
- [x] I have requested at least 1 reviewer for this PR
- [ ] I have made corresponding changes to the documentation
