### PR TITLE
Feature/webumenia 1519 user collections favourite button

### DIFF
--- a/resources/js/components/user-collections/FavouriteButton.vue
+++ b/resources/js/components/user-collections/FavouriteButton.vue
@@ -1,16 +1,24 @@
 <template>
-    <a v-on:click="store.toggleItem(id)" :class="isDetail ? 'btn btn-cta btn-default btn-outline sans w-100' : ''" data-toggle="tooltip" data-placement="left" :title="label">
+    <a v-if="isDetail" v-on:click="store.toggleItem(id)" class="btn btn-cta btn-default btn-outline sans w-100">
         <i class="fa" :class="[store.hasItem(id) ? 'fa-star' : 'fa-star-o']"></i>
-        <span v-if="isDetail">{{ label }}</span>
+        {{ label }}
+    </a>
+    <a v-else v-on:click="store.toggleItem(id)" data-toggle="tooltip" data-placement="left" :title="label">
+        <i class="fa" :class="[store.hasItem(id) ? 'fa-star' : 'fa-star-o']"></i>
     </a>
 </template>
 <script>
     export default {
-        props: ['label', 'id', 'isDetail'],
+        props: ['labelAdd', 'labelRemove', 'id', 'isDetail'],
         data() {
             return {
                 store: this.$root.$data.userCollectionsStore
             }
         },
+        computed: {
+            label: function () {
+              return this.store.hasItem(this.id) ? this.labelRemove : this.labelAdd
+            }
+        }
     }
 </script>

--- a/resources/js/components/user-collections/FavouriteButton.vue
+++ b/resources/js/components/user-collections/FavouriteButton.vue
@@ -1,12 +1,12 @@
 <template>
-    <a data-toggle="tooltip" data-placement="left" :title="label" v-on:click="store.toggleItem(id)">
+    <a v-on:click="store.toggleItem(id)" :class="isDetail ? 'btn btn-cta btn-default btn-outline sans w-100' : ''" data-toggle="tooltip" data-placement="left" :title="label">
         <i class="fa" :class="[store.hasItem(id) ? 'fa-star' : 'fa-star-o']"></i>
+        <span v-if="isDetail">{{ label }}</span>
     </a>
 </template>
-
 <script>
     export default {
-        props: ['label', 'id'],
+        props: ['label', 'id', 'isDetail'],
         data() {
             return {
                 store: this.$root.$data.userCollectionsStore

--- a/resources/lang/cs/general.php
+++ b/resources/lang/cs/general.php
@@ -12,7 +12,8 @@ return array(
     */
 
     'item_zoom'        => 'zoom obrázku',
-    'item_favourite'   => 'přidat mezi oblíbené',
+    'item_add_to_favourites' => 'přidat mezi oblíbené',
+    'item_remove_from_favourites' => 'odebrat z oblíbených',
     'close'            => 'zavřít',
     'back'             => 'zpět',
     'return_home'      => 'návrat domů',

--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -12,7 +12,8 @@ return array(
     */
 
     'item_zoom'        => 'zoom artwork',
-    'item_favourite'   => 'add to favourites',
+    'item_add_to_favourites' => 'add to favourites',
+    'item_remove_from_favourites' => 'remove from favourites',
     'close'            => 'close',
     'back'             => 'back',
     'return_home'      => 'back to home page',

--- a/resources/lang/sk/general.php
+++ b/resources/lang/sk/general.php
@@ -13,6 +13,8 @@ return array(
 
     'item_zoom'        => 'zoom obrázku',
     'item_favourite'   => 'pridať medzi obľúbené',
+    'item_add_to_favourites' => 'pridať medzi obľúbené',
+    'item_remove_from_favourites' => 'odobrať z obľúbených',
     'close'            => 'zavrieť',
     'back'             => 'naspäť',
     'return_home'      => 'návrat domov',

--- a/resources/views/components/artwork_grid_item.blade.php
+++ b/resources/views/components/artwork_grid_item.blade.php
@@ -9,7 +9,8 @@
     <div class="item-title">
         <div class="pull-right">
             <user-collections-favourite-button
-                label="{{ utrans('general.item_favourite') }}"
+                label-add="{{ utrans('general.item_add_to_favourites') }}"
+                label-remove="{{ utrans('general.item_remove_from_favourites') }}"
                 id="{{ $item->id }}"
             ></user-collections-favourite-button>
             @if( !isset($hide_zoom) && $item->has_iip)

--- a/resources/views/dielo.blade.php
+++ b/resources/views/dielo.blade.php
@@ -324,6 +324,11 @@
                     @endif
 
                     <div class="col-md-12 text-center">
+                        <user-collections-favourite-button
+                            label="{{ utrans('general.item_favourite') }}"
+                            id="{{ $item->id }}"
+                            is-detail=true
+                        ></user-collections-favourite-button>
                         @if ($item->isForReproduction())
                         <a href="{!! URL::to('dielo/' . $item->id . '/objednat')  !!}"
                             class="btn btn-cta btn-default btn-outline sans w-100"><i class="fa fa-shopping-cart"></i>

--- a/resources/views/dielo.blade.php
+++ b/resources/views/dielo.blade.php
@@ -328,7 +328,7 @@
                             label-add="{{ utrans('general.item_add_to_favourites') }}"
                             label-remove="{{ utrans('general.item_remove_from_favourites') }}"
                             id="{{ $item->id }}"
-                            is-detail=true
+                            is-detail
                         ></user-collections-favourite-button>
                         @if ($item->isForReproduction())
                         <a href="{!! URL::to('dielo/' . $item->id . '/objednat')  !!}"

--- a/resources/views/dielo.blade.php
+++ b/resources/views/dielo.blade.php
@@ -325,7 +325,8 @@
 
                     <div class="col-md-12 text-center">
                         <user-collections-favourite-button
-                            label="{{ utrans('general.item_favourite') }}"
+                            label-add="{{ utrans('general.item_add_to_favourites') }}"
+                            label-remove="{{ utrans('general.item_remove_from_favourites') }}"
                             id="{{ $item->id }}"
                             is-detail=true
                         ></user-collections-favourite-button>


### PR DESCRIPTION
# Description

<img width="366" alt="Screenshot 2020-12-20 at 12 58 34" src="https://user-images.githubusercontent.com/2682941/102712659-244cc900-42c3-11eb-8702-77eeb6bdd326.png">
<img width="414" alt="Screenshot 2020-12-20 at 12 58 29" src="https://user-images.githubusercontent.com/2682941/102712658-21ea6f00-42c3-11eb-9b21-90962968bd52.png">

tooltips in `artwork_grid_item.blade.php` doesn't behave reactively... but it needs to be changed on the side of tooltips. outside of this task (imho)

Fixes [WEBUMENIA-1519](https://jira.sng.sk/browse/WEBUMENIA-1519)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] I have updated the [CHANGELOG](../CHANGELOG.md)
- [x] I have requested at least 1 reviewer for this PR
- [ ] I have made corresponding changes to the documentation
