### PR TITLE
Do not specify default test branch in deploy config

### DIFF
--- a/.github/workflows/develop-autodeploy.yml
+++ b/.github/workflows/develop-autodeploy.yml
@@ -30,4 +30,4 @@ jobs:
       with:
           ssh-private-key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
           ssh-known-hosts: ${{ secrets.DEPLOY_SSH_KNOWN_HOSTS }}
-    - run: php artisan deploy test
+    - run: php artisan deploy test --branch develop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file[^1].
 ## [Unreleased]
 ### Added
 - user collections
+### Changed
+- Do not specify default (develop) branch for test deploys
 
 ## [2.15.1] - 2021-01-08
 ### Changed

--- a/config/deploy.php
+++ b/config/deploy.php
@@ -160,7 +160,6 @@ return [
             'hostname' => 'webumenia.sk',
             'deploy_path' => '/var/www/test.webumenia.sk',
             'user' => 'lab_sng',
-            'branch' => 'develop'
         ],
     ],
 


### PR DESCRIPTION
To enable easier deployments from dev.

I keep modifying the deploy.php config locally.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have updated the [CHANGELOG](../CHANGELOG.md)
- [x] I have requested at least 1 reviewer for this PR
- [x] I have made corresponding changes to the documentation
