### PR TITLE
Disable bootstrapValidator for select fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file[^1].
 
 ## [Unreleased]
+### Fixed
+- styling issue for selects on reproduction order form
 
 ## [2.22.0] - 2021-03-11
 ### Added

--- a/resources/views/objednavka.blade.php
+++ b/resources/views/objednavka.blade.php
@@ -272,7 +272,7 @@
                 live: 'enabled',
                 submitButtons: 'input[type="submit"]',
                 locale: 'sk_SK',
-                excluded: [':disabled', ':hidden', ':not(:visible)']
+                excluded: [':disabled', ':hidden', ':not(:visible)', 'select']
     })
     .on('change', '#format', function() {
             var isDigital = $(this).val() == 'digitálna reprodukcia';


### PR DESCRIPTION
in reproduction order form.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have updated the [CHANGELOG](../CHANGELOG.md)
- [x] I have requested at least 1 reviewer for this PR
- [ ] I have made corresponding changes to the documentation
