### PR TITLE
Separate display authority sources by newlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file[^1].
 
 ## [Unreleased]
+### Fixed
+- separate authority sources by newlines
 
 ## [2.23.1] - 2021-03-22
 ### Fixed

--- a/resources/views/autor.blade.php
+++ b/resources/views/autor.blade.php
@@ -91,17 +91,21 @@
                     @if ($author->sourceLinks->count() > 0)
                         <div class="links">
                             <h4 class="top-space">{{ utrans('authority.source_links') }}</h4>
-                            @foreach($author->sourceLinks as $link)
-                                <a href="{{ $link->url }}" target="_blank">{{ $link->label }}</a>{{ $loop->last ? '' : ', ' }}
-                            @endforeach
+                            <ul class="list-unstyled">
+                                @foreach($author->sourceLinks as $link)
+                                    <li><a href="{{ $link->url }}" target="_blank">{{ $link->label }}</a></li>
+                                @endforeach
+                            </ul>
                         </div>
                     @endif
                     @if ($author->externalLinks->count() > 0)
                         <div class="links">
                             <h4 class="top-space">{{ utrans('authority.external_links') }}</h4>
-                            @foreach($author->externalLinks as $link)
-                                <a href="{{ $link->url }}" target="_blank">{{ $link->label }}</a>{{ $loop->last ? '' : ', ' }}
-                            @endforeach
+                            <ul class="list-unstyled">
+                                @foreach($author->externalLinks as $link)
+                                    <li><a href="{{ $link->url }}" target="_blank">{{ $link->label }}</a></li>
+                                @endforeach
+                            </ul>
                         </div>
                     @endif
 


### PR DESCRIPTION
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have updated the [CHANGELOG](../CHANGELOG.md)
- [x] I have requested at least 1 reviewer for this PR
- [ ] I have made corresponding changes to the documentation
