### PR TITLE
Clean up Enforcer tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,15 @@ All notable changes to this project will be documented in this file[^1].
 ### Added
 - File uploads management
 
-## [2.25.0] - 2021-04-08
 ### Changed
-- upgrade to Laravel 6
+- Clean up Enforcer tables
 
 ### Fixed
 - Sort options in articles filters by count
+
+## [2.25.0] - 2021-04-08
+### Changed
+- upgrade to Laravel 6
 
 ## [2.24.0] - 2021-03-26
 ### Fixed

--- a/database/migrations/2021_04_08_144036_drop_enforcer_tables.php
+++ b/database/migrations/2021_04_08_144036_drop_enforcer_tables.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class DropEnforcerTables extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::dropIfExists('DELETE_ME_permission_role');
+        Schema::dropIfExists('DELETE_ME_permissions');
+        Schema::dropIfExists('DELETE_ME_role_user');
+        Schema::dropIfExists('DELETE_ME_roles');
+    }
+
+    public function down()
+    {
+        Schema::create('DELETE_ME_roles', function(Blueprint $table) {
+            $table->increments('id');
+        });
+        Schema::create('DELETE_ME_role_user', function(Blueprint $table) {
+            $table->increments('id');
+        });
+        Schema::create('DELETE_ME_permissions', function(Blueprint $table) {
+            $table->increments('id');
+        });
+        Schema::create('DELETE_ME_permission_role', function(Blueprint $table) {
+            $table->increments('id');
+        });
+    }
+}


### PR DESCRIPTION
Clean-up after a successful deployment of Laravel 6 changes.

No rollback (`down`) method provided as it would be very time-consuming (and mostly pointless) to implement.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have updated the [CHANGELOG](../CHANGELOG.md)
- [x] I have requested at least 1 reviewer for this PR
- [x] I have made corresponding changes to the documentation
