### PR TITLE
getAll() returns object with total and data

### DIFF
--- a/app/Harvest/Harvesters/AbstractHarvester.php
+++ b/app/Harvest/Harvesters/AbstractHarvester.php
@@ -45,8 +45,9 @@ abstract class AbstractHarvester
                 $total = count($only_ids);
                 $rows = $this->repository->getRowsById($harvest, $only_ids);
             } else {
-                $total = $this->repository->getTotal($harvest, $from, $to);
-                $rows = $this->repository->getRows($harvest, $from, $to);
+                $result = $this->repository->getAll($harvest, $from, $to);
+                $total = $result->total;
+                $rows = $result->data;
             }
 
             $progress->setTotal($total);

--- a/tests/Harvest/Harvesters/AuthorityHarvesterTest.php
+++ b/tests/Harvest/Harvesters/AuthorityHarvesterTest.php
@@ -37,7 +37,7 @@ class AuthorityHarvesterTest extends TestCase
         ]);
 
         $repositoryMock->expects($this->once())
-            ->method('getRows')
+            ->method('getAll')
             ->willReturn([]);
 
         $harvester = new AuthorityHarvester($repositoryMock, $importerMock);

--- a/tests/Harvest/Harvesters/ItemHarvesterTest.php
+++ b/tests/Harvest/Harvesters/ItemHarvesterTest.php
@@ -65,7 +65,7 @@ class ItemHarvesterTest extends TestCase
         ]);
 
         $repositoryMock->expects($this->once())
-            ->method('getRows')
+            ->method('getAll')
             ->willReturn([]);
 
         $harvester = new ItemHarvester($repositoryMock, $importerMock);

--- a/tests/Harvest/Repositories/AuthorityRepositoryTest.php
+++ b/tests/Harvest/Repositories/AuthorityRepositoryTest.php
@@ -22,7 +22,7 @@ class AuthorityRepositoryTest extends TestCase
         $itemRepository = new AuthorityRepository($endpointFactoryMock);
 
         $harvest = factory(SpiceHarvesterHarvest::class)->make(['base_url' => true]);
-        $rows = $itemRepository->getRows($harvest);
+        $rows = $itemRepository->getAll($harvest)->data;
 
         $rows = iterator_to_array($rows);
         $this->assertCount(1, $rows);

--- a/tests/Harvest/Repositories/ItemRepositoryTest.php
+++ b/tests/Harvest/Repositories/ItemRepositoryTest.php
@@ -22,7 +22,7 @@ class ItemRepositoryTest extends TestCase
         $itemRepository = new ItemRepository($endpointFactoryMock);
 
         $harvest = factory(SpiceHarvesterHarvest::class)->make(['base_url' => true]);
-        $rows = $itemRepository->getRows($harvest);
+        $rows = $itemRepository->getAll($harvest)->data;
 
         $rows = iterator_to_array($rows);
         $this->assertCount(1, $rows);


### PR DESCRIPTION
Proposal based on solution proposed in https://github.com/SlovakNationalGallery/webumenia.sk/pull/503#discussion_r621966737 

TODO: Status is not set to 'complete' if an empty dataset is returned (failing tests).

@igor-kamil feel free to close this if you'd prefer to just get a quick-fix out of the door.