### PR TITLE
Unify filters for articles and collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file[^1].
 
 ## [Unreleased]
+### Changed
+- Unify filters for articles and collections
 
 ## [2.28.1] - 2021-05-13
 ### Fixed

--- a/resources/lang/cs/kolekcie.php
+++ b/resources/lang/cs/kolekcie.php
@@ -16,7 +16,7 @@ return array(
     'collections_items_count'       => 'Kolekce obsahuje',
     'filter' => [
         'author' => 'autor',
-        'type' => 'typ',
+        'type' => 'kategorie',
         'sort_by' => 'podle',
         'sorting' => [
             'updated_at' => 'poslední změny',

--- a/resources/lang/en/kolekcie.php
+++ b/resources/lang/en/kolekcie.php
@@ -16,7 +16,7 @@ return array(
     'collections_items_count'       => 'Colection contains',
     'filter' => [
         'author' => 'author',
-        'type' => 'type',
+        'type' => 'category',
         'sort_by' => 'sort by',
         'sorting' => [
             'updated_at' => 'last updated',

--- a/resources/lang/sk/kolekcie.php
+++ b/resources/lang/sk/kolekcie.php
@@ -16,7 +16,7 @@ return array(
     'collections_items_count'       => 'Kolekcia obsahuje',
     'filter' => [
         'author' => 'autor',
-        'type' => 'typ',
+        'type' => 'kategória',
         'sort_by' => 'zoradiť podľa',
         'sorting' => [
             'updated_at' => 'dátumu aktualizácie',

--- a/resources/views/frontend/articles/index.blade.php
+++ b/resources/views/frontend/articles/index.blade.php
@@ -12,16 +12,16 @@
             <div class="row">
                 <div class="col-md-push-2 col-md-4 col-xs-6">
                     <filter-custom-select
-                        name="category"
-                        placeholder="{{ trans('articles.filter.category') }}"
-                        :options="{{ $categoriesOptions }}"
+                        name="author"
+                        placeholder="{{ trans('articles.filter.author') }}"
+                        :options="{{ $authorsOptions }}"
                     />
                 </div>
                 <div class="col-md-push-2 col-md-4 col-xs-6">
                     <filter-custom-select
-                        name="author"
-                        placeholder="{{ trans('articles.filter.author') }}"
-                        :options="{{ $authorsOptions }}"
+                        name="category"
+                        placeholder="{{ trans('articles.filter.category') }}"
+                        :options="{{ $categoriesOptions }}"
                     />
                 </div>
             </div>


### PR DESCRIPTION
WEBUMENIA-1611

* use "kategória" instead of "typ" in collection list filter
* swap "autor" and "kategória" positions in article list filter

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have updated the [CHANGELOG](../CHANGELOG.md)
- [x] I have requested at least 1 reviewer for this PR
- [x] I have made corresponding changes to the documentation
