### PR TITLE
Deployments to test use chmod instead of setfacl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file[^1].
 
 ## [Unreleased]
+### Fixed
+- Deployments to test use chmod instead of setfacl
+
 ### Changed
 - Editor role can edit articles
 - Speed up CI tests by using docker build caching

--- a/config/deploy.php
+++ b/config/deploy.php
@@ -162,6 +162,13 @@ return [
             'hostname' => 'webumenia.sk',
             'deploy_path' => '/var/www/test.webumenia.sk',
             'user' => 'lab_sng',
+            'writable_mode' => 'chmod',
+            'writable_chmod_mode' => '775',
+            'writable_dirs' => [
+                'bootstrap/cache',
+                'storage/app/public',
+                'storage/logs',
+            ],
         ],
     ],
 


### PR DESCRIPTION
Deployments broken by test.webumenia.sk storage not supporting ACL operations

WEBUMENIA-1632

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have updated the [CHANGELOG](../CHANGELOG.md)
- [x] I have requested at least 1 reviewer for this PR
- [ ] I have made corresponding changes to the documentation
