### PR TITLE
Do not set (most) writable_dirs in test

### DIFF
--- a/config/deploy.php
+++ b/config/deploy.php
@@ -168,8 +168,6 @@ return [
             'writable_chmod_mode' => '775',
             'writable_dirs' => [
                 'bootstrap/cache',
-                'storage/app/public',
-                'storage/logs',
             ],
         ],
     ],


### PR DESCRIPTION
Because lab_sng does not have permissions to `chmod` files owned by data-www

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (link to Jira or GitHub issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] I have updated the [CHANGELOG](../CHANGELOG.md)
- [x] I have requested at least 1 reviewer for this PR
- [ ] I have made corresponding changes to the documentation
