### PR TITLE
Fix "alternate" hreflangs not referencing each other

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file[^1].
 ### Added
 - Newsletter signup modal and inline form
 
+### Fixed
+- "alternate" hreflangs not referencing each other
+
 ## [2.35.0] - 2021-11-22
 ### Changed
 - shared user collections to show publicly

--- a/resources/views/includes/hreflangs.blade.php
+++ b/resources/views/includes/hreflangs.blade.php
@@ -1,3 +1,0 @@
-@foreach($localizedURLs as $localeCode => $URL)
-<link rel="alternate" hreflang="{{$localeCode}}" href="{{ $URL }}">
-@endforeach

--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -15,17 +15,15 @@
 			@show
 		</title>
 
-		<!--  favicons-->
 		@include('includes.favicons')
-		<!--  /favicons-->
-		<!--  Open Graph protocol -->
-    @include('includes.og_tags')
-    <!--  /Open Graph protocol -->
-    <!--  hreflangs -->
-		@include('includes.hreflangs', [
-      'localizedURLs' => getLocalizedURLArray(),
-    ])
-		<!--  /hreflangs -->
+		@include('includes.og_tags')
+
+		@foreach(LaravelLocalization::getSupportedLanguagesKeys() as $locale)
+		<link rel="alternate" hreflang="{{ $locale }}" href="{{ LaravelLocalization::getLocalizedURL($locale, url()->current(), [], true) }}">
+		@endforeach
+		{{-- "default" url with locale hidden --}}
+		<link rel="alternate" hreflang="{{ LaravelLocalization::getDefaultLocale() }}" href="{{ LaravelLocalization::getNonLocalizedURL(url()->current()) }}">
+
 
 		@yield('link')
 


### PR DESCRIPTION
Includes the 'implied' locale URL which resulted in errors in search console:
![image](https://user-images.githubusercontent.com/1374745/143442037-bfbd8821-87de-45e0-b610-835b00a460d5.png)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have updated the [CHANGELOG](../CHANGELOG.md)
- [x] I have requested at least 1 reviewer for this PR
- [ ] I have made corresponding changes to the documentation
