### PR TITLE
User "claims" collection only after create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file[^1].
 
 ### Fixed
 - "alternate" hreflangs not referencing each other
+- shared collection added to user collections only after create
 
 ## [2.35.0] - 2021-11-22
 ### Changed

--- a/resources/js/components/user-collections/ShareForm.vue
+++ b/resources/js/components/user-collections/ShareForm.vue
@@ -10,6 +10,7 @@ const store = require('./store')
 export default {
     props: {
         action: String,
+        addToUserCollections: Boolean,
         creating: Boolean,
         publicId: String,
         updateToken: String,
@@ -22,7 +23,7 @@ export default {
     mounted() {
         if (!this.publicId || !this.updateToken) return
 
-        if (!store.hasSharedCollection(this.publicId)) {
+        if (this.addToUserCollections && !store.hasSharedCollection(this.publicId)) {
             store.addSharedCollection(this.publicId, this.updateToken)
         }
     },

--- a/resources/views/components/user-collections/share-form.blade.php
+++ b/resources/views/components/user-collections/share-form.blade.php
@@ -3,6 +3,7 @@
         public-id="{{ optional($collection)->public_id }}"
         update-token="{{ optional($collection)->update_token }}"
         :creating="@json($creating)"
+        :add-to-user-collections="@json(session('user-collection-created') === true)"
         v-slot="form"
     >
     @method($method)


### PR DESCRIPTION
Up until now, if you come to an 'edit' link for a collection, this collection will be automatically added to your collecions (in user storage). 

This fix introduces a change, when this 'claiming' only happens after create.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have updated the [CHANGELOG](../CHANGELOG.md)
- [x] I have requested at least 1 reviewer for this PR
- [ ] I have made corresponding changes to the documentation
