### PR TITLE
Fix alternate hreflangs not including URL params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file[^1].
 ## [Unreleased]
 ### Fixed
 - gender sensitive translation strings in author profile
+- "alternate" hreflangs not including URL (query) params
 
 ## [2.36.0] - 2021-11-26
 ### Added

--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -19,10 +19,10 @@
 		@include('includes.og_tags')
 
 		@foreach(LaravelLocalization::getSupportedLanguagesKeys() as $locale)
-		<link rel="alternate" hreflang="{{ $locale }}" href="{{ LaravelLocalization::getLocalizedURL($locale, url()->current(), [], true) }}">
+		<link rel="alternate" hreflang="{{ $locale }}" href="{{ LaravelLocalization::getLocalizedURL($locale, null, [], true) }}">
 		@endforeach
 		{{-- "default" url with locale hidden --}}
-		<link rel="alternate" hreflang="{{ LaravelLocalization::getDefaultLocale() }}" href="{{ LaravelLocalization::getNonLocalizedURL(url()->current()) }}">
+		<link rel="alternate" hreflang="{{ LaravelLocalization::getDefaultLocale() }}" href="{{ LaravelLocalization::getNonLocalizedURL() }}">
 
 
 		@yield('link')


### PR DESCRIPTION
URL params are now incuded, e.g.

```html
<link rel="alternate" hreflang="en" href="http://localhost:8000/en/katalog?has_iip=1&amp;is_free=1&amp;years-range=1450%2C2006">
<link rel="alternate" hreflang="sk" href="http://localhost:8000/sk/katalog?has_iip=1&amp;is_free=1&amp;years-range=1450%2C2006">
<link rel="alternate" hreflang="cs" href="http://localhost:8000/cs/katalog?has_iip=1&amp;is_free=1&amp;years-range=1450%2C2006">
<link rel="alternate" hreflang="sk" href="http://localhost:8000/katalog?has_iip=1&amp;is_free=1&amp;years-range=1450%2C2006">
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have updated the [CHANGELOG](../CHANGELOG.md)
- [x] I have requested at least 1 reviewer for this PR
- [ ] I have made corresponding changes to the documentation
