### PR TITLE
Feature/webumenia 1584 add gender filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file[^1].
 
 ## [Unreleased]
+### Added
+- filter by gender to authorities
 
 ## [2.40.0] - 2021-12-23
 ### Added

--- a/app/Authority.php
+++ b/app/Authority.php
@@ -286,7 +286,7 @@ class Authority extends Model implements IndexableModel, TranslatableContract
             'role' => $this->roles,
             'birth_year' => $this->birth_year,
             'death_year' => $this->death_year,
-            'sex' => $this->sex,
+            'sex' => trans('authority.sex.' . $this->sex, [], $locale),
             'has_image' => (boolean) $this->has_image,
             'created_at' => $this->created_at->format('Y-m-d H:i:s'),
             'items_count' => $this->items()->count(),

--- a/app/Filter/AuthorityFilter.php
+++ b/app/Filter/AuthorityFilter.php
@@ -17,12 +17,15 @@ class AuthorityFilter extends AbstractFilter
 
     protected $place;
 
+    protected $sex;
+
     protected $firstLetter;
 
     protected $filterables = [
         'role',
         'nationality',
         'place',
+        'sex',
     ];
 
     public static function loadValidatorMetadata(ClassMetadata $metadata)
@@ -71,6 +74,17 @@ class AuthorityFilter extends AbstractFilter
     public function setPlace(?string $place): AuthorityFilter
     {
         $this->place = $place;
+        return $this;
+    }
+
+    public function getSex(): ?string
+    {
+        return $this->sex;
+    }
+
+    public function setSex(?string $sex): AuthorityFilter
+    {
+        $this->sex = $sex;
         return $this;
     }
 

--- a/app/Filter/Forms/Types/AuthoritySearchRequestType.php
+++ b/app/Filter/Forms/Types/AuthoritySearchRequestType.php
@@ -69,7 +69,8 @@ class AuthoritySearchRequestType extends AbstractType
                 ])
                 ->add('role', ChoiceType::class, $getChoiceOptions('role'))
                 ->add('nationality', ChoiceType::class, $getChoiceOptions('nationality'))
-                ->add('place', ChoiceType::class, $getChoiceOptions('place'));
+                ->add('place', ChoiceType::class, $getChoiceOptions('place'))
+                ->add('sex', ChoiceType::class, $getChoiceOptions('sex'));
         });
 
         $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) {

--- a/resources/lang/cs/authority.php
+++ b/resources/lang/cs/authority.php
@@ -44,6 +44,7 @@ return array(
             'role' => 'role: :value',
             'nationality' => 'příslušnost: :value',
             'place' => 'místo: :value',
+            'sex' => 'pohlaví',
             'years' => 'v letech :from — :to',
         ],
         'sort_by' => 'podle',

--- a/resources/lang/cs/authority.php
+++ b/resources/lang/cs/authority.php
@@ -91,5 +91,9 @@ return array(
         "workshop" => "dílna autora",
         "concept" => "autor konceptu",
         "photograph" => "autor fotografie",
+    ],
+    'sex'=>[
+        'male' => 'muž',
+        'female' => 'žena',
     ]
 );

--- a/resources/lang/en/authority.php
+++ b/resources/lang/en/authority.php
@@ -88,5 +88,9 @@ return array(
         "workshop" => "workshop of",
         "concept" => "concept by",
         "photograph" => "photographer",
+    ],
+    'sex'=>[
+        'male' => 'male',
+        'female' => 'female',
     ]
 );

--- a/resources/lang/en/authority.php
+++ b/resources/lang/en/authority.php
@@ -36,6 +36,7 @@ return array(
         'role' => 'role',
         'nationality' => 'nationality',
         'place' => 'location',
+        'sex' => 'gender',
         'title_generator' => [
             'first_letter' => 'first letter: :value',
             'role' => 'role: :value',

--- a/resources/lang/sk/authority.php
+++ b/resources/lang/sk/authority.php
@@ -39,6 +39,7 @@ return array(
         'role' => 'rola',
         'nationality' => 'príslušnosť',
         'place' => 'miesto',
+        'sex' => 'pohlavie',
         'title_generator' => [
             'first_letter' => 'začína sa na: :value',
             'role' => 'rola: :value',

--- a/resources/lang/sk/authority.php
+++ b/resources/lang/sk/authority.php
@@ -91,5 +91,9 @@ return array(
         "workshop" => "dielňa autora",
         "concept" => "autor konceptu",
         "photograph" => "autor fotografie",
+    ],
+    'sex'=>[
+        'male' => 'muž',
+        'female' => 'žena',
     ]
 );

--- a/resources/views/frontend/authors/form.blade.php
+++ b/resources/views/frontend/authors/form.blade.php
@@ -3,14 +3,17 @@
 <section class="filters">
     <div class="container content-section">
         <div class="row">
-            <div  class="col-md-4 col-xs-6 bottom-space">
+            <div  class="col-md-3 col-xs-6 bottom-space">
                 @formWidget($form['role'], ['attr' => ['class' => 'js-custom-select']])
             </div>
-            <div  class="col-md-4 col-xs-6 bottom-space">
+            <div  class="col-md-3 col-xs-6 bottom-space">
                 @formWidget($form['nationality'], ['attr' => ['class' => 'js-custom-select']])
             </div>
-            <div  class="col-md-4 col-xs-6 bottom-space">
+            <div  class="col-md-3 col-xs-6 bottom-space">
                 @formWidget($form['place'], ['attr' => ['class' => 'js-custom-select']])
+            </div>
+            <div  class="col-md-3 col-xs-6 bottom-space">
+                @formWidget($form['sex'], ['attr' => ['class' => 'js-custom-select']])
             </div>
         </div>
         <div class="row">


### PR DESCRIPTION
<img width="1234" alt="Screenshot 2022-01-03 at 23 05 18" src="https://user-images.githubusercontent.com/2682941/147985583-e882a93e-8518-418c-9864-898b0706675e.png">

⚠️  This requires to reindex authorities: `php artisan es:reindex authorities`
❓ I am wondering, whether to store translated or non-translated version in the ES index. On one side - it makes sense to store in SK index only SK values. On the other hand it will behave differently when you query DB and ES -> and this inconsistency makes me bit nervous. Also in this way it's harder to appropriate no-image placeholders by gender (what doesn't work anyway right now). What's your opinion @eronisko @rastislav-chynoransky ? 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have updated the [CHANGELOG](../CHANGELOG.md)
- [ ] I have requested at least 1 reviewer for this PR
- [ ] I have made corresponding changes to the documentation
