### PR TITLE
Fix/webumenia 1628 public domain artworks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file[^1].
 
 ## [Unreleased]
+### Fixed
+- calculation of isFree for artworks with authorities without death_year
 
 ## [2.40.1] - 2022-01-04
 ### Fixed

--- a/app/Item.php
+++ b/app/Item.php
@@ -511,8 +511,6 @@ class Item extends Model implements IndexableModel, TranslatableContract
         foreach ($this->authorities as $authority) {
             if (!empty($authority->death_year)) {
                 $copyrightExpirationYears[] = $authority->death_year + self::COPYRIGHT_LENGTH + 1;
-            } else {
-                return self::FREE_NEVER;
             }
         }
 

--- a/tests/Models/ItemTest.php
+++ b/tests/Models/ItemTest.php
@@ -49,14 +49,6 @@ class ItemTest extends TestCase
         $this->assertFalse($item->isFree());
     }
 
-    public function testIsFreeAuthorDeathYearNull() {
-        $item = $this->createFreeItem();
-        $item->date_latest = date('Y');
-        $authority = factory(Authority::class)->make(['death_year' => null]);
-        $item->authorities->add($authority);
-        $this->assertTrue($item->isFree());
-    }
-
     public function testIsFreeAuthorDeathYearNow() {
         $item = $this->createFreeItem();
         $item->date_latest = date('Y');

--- a/tests/Models/ItemTest.php
+++ b/tests/Models/ItemTest.php
@@ -35,7 +35,7 @@ class ItemTest extends TestCase
         $authority = factory(Authority::class)->make(['death_year' => null]);
         $item->authorities->add($authority);
 
-        $this->assertEquals(Item::FREE_NEVER, $item->freeFrom());
+        $this->assertTrue($item->isFree());
     }
 
     public function testIsFree() {
@@ -54,7 +54,7 @@ class ItemTest extends TestCase
         $item->date_latest = date('Y');
         $authority = factory(Authority::class)->make(['death_year' => null]);
         $item->authorities->add($authority);
-        $this->assertFalse($item->isFree());
+        $this->assertTrue($item->isFree());
     }
 
     public function testIsFreeAuthorDeathYearNow() {


### PR DESCRIPTION
# Description

This is fixing the [issue](https://jira.sng.sk/browse/WEBUMENIA-1628), when artwork with existing authority without `death_year` is autmaticaly prevented from downloading.
However for some authorities the `death_year` is missing just because it's unknown. 
This doesn't break anything for "really alive" authors -> since the `$this->date_latest + self::GUESSED_AUTHORISM_TIMESPAN + self::COPYRIGHT_LENGTH + 1` should be definitely enough. 

Fixes https://jira.sng.sk/browse/WEBUMENIA-1628

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have updated the [CHANGELOG](../CHANGELOG.md)
- [x] I have requested at least 1 reviewer for this PR
- [ ] I have made corresponding changes to the documentation
