### PR TITLE
RFC: Tailwind experiment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ public/sitemap.xml
 /public/css/admin.css
 /public/css/mail
 /public/css/style.css
+/public/css/app-tailwind.css
 /public/fonts
 /public/hot
 /public/js/*LICENSE.txt

--- a/package-lock.json
+++ b/package-lock.json
@@ -1599,6 +1599,31 @@
             "integrity": "sha512-FlVvVFA1TX6l3lp8VjDnYYq7R1nyW6x3svAt4nDgrWQ9SBaSh9CnbwgSUTasgfNfOG5HlM1ehugCvM+hjo56LA==",
             "dev": true
         },
+        "acorn-node": {
+            "version": "1.8.2",
+            "resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.8.2.tgz",
+            "integrity": "sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==",
+            "dev": true,
+            "requires": {
+                "acorn": "^7.0.0",
+                "acorn-walk": "^7.0.0",
+                "xtend": "^4.0.2"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "7.4.1",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+                    "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+                    "dev": true
+                }
+            }
+        },
+        "acorn-walk": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
+            "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
+            "dev": true
+        },
         "adjust-sourcemap-loader": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/adjust-sourcemap-loader/-/adjust-sourcemap-loader-3.0.0.tgz",
@@ -1712,6 +1737,12 @@
                     }
                 }
             }
+        },
+        "arg": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.1.tgz",
+            "integrity": "sha512-e0hDa9H2Z9AwFkk2qDlwhoMYE4eToKarchkQHovNdLTCYMHZHeRjI71crOh+dio4K6u1IcwubQqo79Ga4CyAQA==",
+            "dev": true
         },
         "arity-n": {
             "version": "1.0.4",
@@ -1861,17 +1892,56 @@
             "dev": true
         },
         "autoprefixer": {
-            "version": "10.3.5",
-            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.3.5.tgz",
-            "integrity": "sha512-2H5kQSsyoOMdIehTzIt/sC9ZDIgWqlkG/dbevm9B9xQZ1TDPBHpNUDW5ENqqQQzuaBWEo75JkV0LJe+o5Lnr5g==",
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.2.tgz",
+            "integrity": "sha512-9fOPpHKuDW1w/0EKfRmVnxTDt8166MAnLI3mgZ1JCnhNtYWxcJ6Ud5CO/AVOZi/AvFa8DY9RTy3h3+tFBlrrdQ==",
             "dev": true,
             "requires": {
-                "browserslist": "^4.17.1",
-                "caniuse-lite": "^1.0.30001259",
-                "fraction.js": "^4.1.1",
-                "nanocolors": "^0.1.5",
+                "browserslist": "^4.19.1",
+                "caniuse-lite": "^1.0.30001297",
+                "fraction.js": "^4.1.2",
                 "normalize-range": "^0.1.2",
-                "postcss-value-parser": "^4.1.0"
+                "picocolors": "^1.0.0",
+                "postcss-value-parser": "^4.2.0"
+            },
+            "dependencies": {
+                "browserslist": {
+                    "version": "4.19.1",
+                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.19.1.tgz",
+                    "integrity": "sha512-u2tbbG5PdKRTUoctO3NBD8FQ5HdPh1ZXPHzp1rwaa5jTc+RV9/+RlWiAIKmjRPQF+xbGM9Kklj5bZQFa2s/38A==",
+                    "dev": true,
+                    "requires": {
+                        "caniuse-lite": "^1.0.30001286",
+                        "electron-to-chromium": "^1.4.17",
+                        "escalade": "^3.1.1",
+                        "node-releases": "^2.0.1",
+                        "picocolors": "^1.0.0"
+                    }
+                },
+                "caniuse-lite": {
+                    "version": "1.0.30001300",
+                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001300.tgz",
+                    "integrity": "sha512-cVjiJHWGcNlJi8TZVKNMnvMid3Z3TTdDHmLDzlOdIiZq138Exvo0G+G0wTdVYolxKb4AYwC+38pxodiInVtJSA==",
+                    "dev": true
+                },
+                "electron-to-chromium": {
+                    "version": "1.4.49",
+                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.49.tgz",
+                    "integrity": "sha512-k/0t1TRfonHIp8TJKfjBu2cKj8MqYTiEpOhci+q7CVEE5xnCQnx1pTa+V8b/sdhe4S3PR4p4iceEQWhGrKQORQ==",
+                    "dev": true
+                },
+                "node-releases": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.1.tgz",
+                    "integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==",
+                    "dev": true
+                },
+                "postcss-value-parser": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+                    "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+                    "dev": true
+                }
             }
         },
         "aws-sign2": {
@@ -2382,6 +2452,12 @@
             "version": "5.3.1",
             "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
             "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+            "dev": true
+        },
+        "camelcase-css": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+            "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
             "dev": true
         },
         "caniuse-api": {
@@ -3270,6 +3346,12 @@
                 }
             }
         },
+        "defined": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+            "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+            "dev": true
+        },
         "del": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/del/-/del-6.0.0.tgz",
@@ -3353,6 +3435,23 @@
             "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
             "dev": true
         },
+        "detective": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/detective/-/detective-5.2.0.tgz",
+            "integrity": "sha512-6SsIx+nUUbuK0EthKjv0zrdnajCCXVYGmbYYiYjFVpzcjwEs/JMDZ8tPRG29J/HhN56t3GJp2cGSWDRjjot8Pg==",
+            "dev": true,
+            "requires": {
+                "acorn-node": "^1.6.1",
+                "defined": "^1.0.0",
+                "minimist": "^1.1.1"
+            }
+        },
+        "didyoumean": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+            "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+            "dev": true
+        },
         "diffie-hellman": {
             "version": "5.0.3",
             "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
@@ -3380,6 +3479,12 @@
             "requires": {
                 "path-type": "^4.0.0"
             }
+        },
+        "dlv": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+            "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+            "dev": true
         },
         "dns-equal": {
             "version": "1.0.0",
@@ -4321,9 +4426,9 @@
             "dev": true
         },
         "fraction.js": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.1.1.tgz",
-            "integrity": "sha512-MHOhvvxHTfRFpF1geTK9czMIZ6xclsEor2wkIGYYq+PxcQqT7vStJqjhe6S1TenZrMZzo+wlqOufBDVepUEgPg==",
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.1.2.tgz",
+            "integrity": "sha512-o2RiJQ6DZaR/5+Si0qJUIy637QMRudSi9kU/FFzx9EZazrIdnBgpU+3sEWCxAVhH2RtxW2Oz+T4p2o8uOPVcgA==",
             "dev": true
         },
         "fragment-cache": {
@@ -6800,7 +6905,7 @@
         },
         "mkdirp": {
             "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
             "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
             "dev": true,
             "optional": true,
@@ -6810,7 +6915,7 @@
             "dependencies": {
                 "minimist": {
                     "version": "0.0.8",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                    "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                     "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
                     "dev": true,
                     "optional": true
@@ -6853,9 +6958,9 @@
             "dev": true
         },
         "nanoid": {
-            "version": "3.1.25",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-            "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
+            "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==",
             "dev": true
         },
         "nanomatch": {
@@ -7101,6 +7206,12 @@
                     }
                 }
             }
+        },
+        "object-hash": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+            "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+            "dev": true
         },
         "object-is": {
             "version": "1.1.5",
@@ -7483,6 +7594,12 @@
             "integrity": "sha1-ZzhPClkz2770C+qwqzHQuMWC/4g=",
             "dev": true
         },
+        "picocolors": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+            "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+            "dev": true
+        },
         "picomatch": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
@@ -7542,14 +7659,14 @@
             "dev": true
         },
         "postcss": {
-            "version": "8.3.7",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.7.tgz",
-            "integrity": "sha512-9SaY7nnyQ63/WittqZYAvkkYPyKxchMKH71UDzeTmWuLSvxTRpeEeABZAzlCi55cuGcoFyoV/amX2BdsafQidQ==",
+            "version": "8.4.5",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.5.tgz",
+            "integrity": "sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==",
             "dev": true,
             "requires": {
-                "nanocolors": "^0.1.5",
-                "nanoid": "^3.1.25",
-                "source-map-js": "^0.6.2"
+                "nanoid": "^3.1.30",
+                "picocolors": "^1.0.0",
+                "source-map-js": "^1.0.1"
             }
         },
         "postcss-calc": {
@@ -7606,6 +7723,15 @@
             "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.0.1.tgz",
             "integrity": "sha512-Y28H7y93L2BpJhrdUR2SR2fnSsT+3TVx1NmVQLbcnZWwIUpJ7mfcTC6Za9M2PG6w8j7UQRfzxqn8jU2VwFxo3Q==",
             "dev": true
+        },
+        "postcss-js": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.0.tgz",
+            "integrity": "sha512-77QESFBwgX4irogGVPgQ5s07vLvFqWr228qZY+w6lW599cRlK/HmnlivnnVUxkjHnCu4J16PDMHcH+e+2HbvTQ==",
+            "dev": true,
+            "requires": {
+                "camelcase-css": "^2.0.1"
+            }
         },
         "postcss-load-config": {
             "version": "3.1.0",
@@ -7740,6 +7866,15 @@
             "dev": true,
             "requires": {
                 "icss-utils": "^5.0.0"
+            }
+        },
+        "postcss-nested": {
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-5.0.6.tgz",
+            "integrity": "sha512-rKqm2Fk0KbA8Vt3AdGN0FB9OBOMDVajMG6ZCf/GoHgdxUJ4sBFp0A/uMIRm+MJUdo33YXEtjqIz8u7DAp8B7DA==",
+            "dev": true,
+            "requires": {
+                "postcss-selector-parser": "^6.0.6"
             }
         },
         "postcss-normalize-charset": {
@@ -8018,6 +8153,12 @@
             "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
             "dev": true
         },
+        "quick-lru": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+            "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+            "dev": true
+        },
         "randombytes": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -8200,7 +8341,7 @@
             "dependencies": {
                 "jsesc": {
                     "version": "0.5.0",
-                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+                    "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
                     "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
                     "dev": true
                 }
@@ -8966,9 +9107,9 @@
             "dev": true
         },
         "source-map-js": {
-            "version": "0.6.2",
-            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
-            "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+            "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
             "dev": true
         },
         "source-map-resolve": {
@@ -9240,6 +9381,12 @@
                 "has-flag": "^3.0.0"
             }
         },
+        "supports-preserve-symlinks-flag": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+            "dev": true
+        },
         "svgo": {
             "version": "2.7.0",
             "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.7.0.tgz",
@@ -9253,6 +9400,240 @@
                 "csso": "^4.2.0",
                 "nanocolors": "^0.1.12",
                 "stable": "^0.1.8"
+            }
+        },
+        "tailwindcss": {
+            "version": "3.0.15",
+            "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.0.15.tgz",
+            "integrity": "sha512-bT2iy7FtjwgsXik4ZoJnHXR+SRCiGR1W95fVqpLZebr64m4ahwUwRbIAc5w5+2fzr1YF4Ct2eI7dojMRRl8sVQ==",
+            "dev": true,
+            "requires": {
+                "arg": "^5.0.1",
+                "chalk": "^4.1.2",
+                "chokidar": "^3.5.2",
+                "color-name": "^1.1.4",
+                "cosmiconfig": "^7.0.1",
+                "detective": "^5.2.0",
+                "didyoumean": "^1.2.2",
+                "dlv": "^1.1.3",
+                "fast-glob": "^3.2.7",
+                "glob-parent": "^6.0.2",
+                "is-glob": "^4.0.3",
+                "normalize-path": "^3.0.0",
+                "object-hash": "^2.2.0",
+                "postcss-js": "^4.0.0",
+                "postcss-load-config": "^3.1.0",
+                "postcss-nested": "5.0.6",
+                "postcss-selector-parser": "^6.0.8",
+                "postcss-value-parser": "^4.2.0",
+                "quick-lru": "^5.1.1",
+                "resolve": "^1.21.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "anymatch": {
+                    "version": "3.1.2",
+                    "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+                    "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+                    "dev": true,
+                    "requires": {
+                        "normalize-path": "^3.0.0",
+                        "picomatch": "^2.0.4"
+                    }
+                },
+                "binary-extensions": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+                    "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+                    "dev": true
+                },
+                "braces": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+                    "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+                    "dev": true,
+                    "requires": {
+                        "fill-range": "^7.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+                    "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "chokidar": {
+                    "version": "3.5.3",
+                    "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+                    "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+                    "dev": true,
+                    "requires": {
+                        "anymatch": "~3.1.2",
+                        "braces": "~3.0.2",
+                        "fsevents": "~2.3.2",
+                        "glob-parent": "~5.1.2",
+                        "is-binary-path": "~2.1.0",
+                        "is-glob": "~4.0.1",
+                        "normalize-path": "~3.0.0",
+                        "readdirp": "~3.6.0"
+                    },
+                    "dependencies": {
+                        "glob-parent": {
+                            "version": "5.1.2",
+                            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+                            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+                            "dev": true,
+                            "requires": {
+                                "is-glob": "^4.0.1"
+                            }
+                        }
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "fill-range": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+                    "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+                    "dev": true,
+                    "requires": {
+                        "to-regex-range": "^5.0.1"
+                    }
+                },
+                "fsevents": {
+                    "version": "2.3.2",
+                    "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+                    "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+                    "dev": true,
+                    "optional": true
+                },
+                "glob-parent": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+                    "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+                    "dev": true,
+                    "requires": {
+                        "is-glob": "^4.0.3"
+                    }
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "is-binary-path": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+                    "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+                    "dev": true,
+                    "requires": {
+                        "binary-extensions": "^2.0.0"
+                    }
+                },
+                "is-core-module": {
+                    "version": "2.8.1",
+                    "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
+                    "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+                    "dev": true,
+                    "requires": {
+                        "has": "^1.0.3"
+                    }
+                },
+                "is-glob": {
+                    "version": "4.0.3",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+                    "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "^2.1.1"
+                    }
+                },
+                "is-number": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+                    "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+                    "dev": true
+                },
+                "postcss-selector-parser": {
+                    "version": "6.0.9",
+                    "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.9.tgz",
+                    "integrity": "sha512-UO3SgnZOVTwu4kyLR22UQ1xZh086RyNZppb7lLAKBFK8a32ttG5i87Y/P3+2bRSjZNyJ1B7hfFNo273tKe9YxQ==",
+                    "dev": true,
+                    "requires": {
+                        "cssesc": "^3.0.0",
+                        "util-deprecate": "^1.0.2"
+                    }
+                },
+                "postcss-value-parser": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+                    "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+                    "dev": true
+                },
+                "readdirp": {
+                    "version": "3.6.0",
+                    "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+                    "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+                    "dev": true,
+                    "requires": {
+                        "picomatch": "^2.2.1"
+                    }
+                },
+                "resolve": {
+                    "version": "1.21.0",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.21.0.tgz",
+                    "integrity": "sha512-3wCbTpk5WJlyE4mSOtDLhqQmGFi0/TD9VPwmiolnk8U0wRgMEktqCXd3vy5buTO3tljvalNvKrjHEfrd2WpEKA==",
+                    "dev": true,
+                    "requires": {
+                        "is-core-module": "^2.8.0",
+                        "path-parse": "^1.0.7",
+                        "supports-preserve-symlinks-flag": "^1.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                },
+                "to-regex-range": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+                    "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-number": "^7.0.0"
+                    }
+                }
             }
         },
         "tapable": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
         "production": "mix --production"
     },
     "devDependencies": {
+        "autoprefixer": "^10.4.2",
         "cross-env": "^5.1",
         "jquery": "^3.5.0",
         "laravel-mix": "^6.0.31",
@@ -17,9 +18,11 @@
         "less": "^3.11.1",
         "less-loader": "^5.0.0",
         "livewire-vue": "^0.3.1",
+        "postcss": "^8.4.5",
         "resolve-url-loader": "^3.1.2",
         "sass": "^1.15.2",
         "sass-loader": "^7.1.0",
+        "tailwindcss": "^3.0.15",
         "vue": "^2.6.12",
         "vue-loader": "^15.9.8",
         "vue-template-compiler": "^2.6.12"

--- a/resources/css/app-tailwind.css
+++ b/resources/css/app-tailwind.css
@@ -10,32 +10,32 @@
     See https://tailwindcss.com/docs/configuration#important
     */
 
-    #tailwind-rules h1 {
+    .tailwind-rules h1 {
         font-size: inherit;
         font-weight: inherit;
         margin: 0;
     }
-    #tailwind-rules h2 {
+    .tailwind-rules h2 {
         font-size: inherit;
         font-weight: inherit;
         margin: 0;
     }
-    #tailwind-rules h3 {
+    .tailwind-rules h3 {
         font-size: inherit;
         font-weight: inherit;
         margin: 0;
     }
-    #tailwind-rules h4 {
+    .tailwind-rules h4 {
         font-size: inherit;
         font-weight: inherit;
         margin: 0;
     }
-    #tailwind-rules h5 {
+    .tailwind-rules h5 {
         font-size: inherit;
         font-weight: inherit;
         margin: 0;
     }
-    #tailwind-rules h6 {
+    .tailwind-rules h6 {
         font-size: inherit;
         font-weight: inherit;
         margin: 0;

--- a/resources/css/app-tailwind.css
+++ b/resources/css/app-tailwind.css
@@ -1,0 +1,43 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+
+    /*
+    Disable current default styling.
+    Tailwind styling will work thanks to the 'important' config.
+    See https://tailwindcss.com/docs/configuration#important
+    */
+
+    #tailwind-rules h1 {
+        font-size: inherit;
+        font-weight: inherit;
+        margin: 0;
+    }
+    #tailwind-rules h2 {
+        font-size: inherit;
+        font-weight: inherit;
+        margin: 0;
+    }
+    #tailwind-rules h3 {
+        font-size: inherit;
+        font-weight: inherit;
+        margin: 0;
+    }
+    #tailwind-rules h4 {
+        font-size: inherit;
+        font-weight: inherit;
+        margin: 0;
+    }
+    #tailwind-rules h5 {
+        font-size: inherit;
+        font-weight: inherit;
+        margin: 0;
+    }
+    #tailwind-rules h6 {
+        font-size: inherit;
+        font-weight: inherit;
+        margin: 0;
+    }
+}

--- a/resources/views/home/index.blade.php
+++ b/resources/views/home/index.blade.php
@@ -24,11 +24,11 @@
 @stop
 
 @section('content')
-    <div id="tailwind-rules" class="container">
-        <h3 class="tw-text tw-text-2xl tw-font-semibold">Nový obsah</h3>
-        <div class="tw-flex tw-underline-offset-4 tw-text-5xl tw-font-semibold tw-cursor-pointer">
-            <h4 class="hover:tw-text-gray-500 tw-underline">Kolekcie</h4>
-            <h4 class="hover:tw-text-gray-500 tw-underline tw-text-gray-400 tw-ml-4">Články</h4>
+    <div class="tailwind-rules container">
+        <h3 class="tw-text-4xl tw-font-semibold">Nový obsah</h3>
+        <div class="tw-flex tw-underline-offset-4 tw-text-5xl tw-font-semibold tw-cursor-pointer tw-mt-8">
+            <h4 class="tw-transition hover:tw-text-gray-500 tw-underline">Kolekcie</h4>
+            <h4 class="tw-transition hover:tw-text-gray-500 tw-underline tw-text-gray-400 tw-ml-4">Články</h4>
         </div>
     </div>
 @stop

--- a/resources/views/home/index.blade.php
+++ b/resources/views/home/index.blade.php
@@ -24,5 +24,11 @@
 @stop
 
 @section('content')
-
+    <div id="tailwind-rules" class="container">
+        <h3 class="tw-text tw-text-2xl tw-font-semibold">Nový obsah</h3>
+        <div class="tw-flex tw-underline-offset-4 tw-text-5xl tw-font-semibold tw-cursor-pointer">
+            <h4 class="hover:tw-text-gray-500 tw-underline">Kolekcie</h4>
+            <h4 class="hover:tw-text-gray-500 tw-underline tw-text-gray-400 tw-ml-4">Články</h4>
+        </div>
+    </div>
 @stop

--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -30,6 +30,7 @@
 		<!-- CSS are placed here -->
 		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
 		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.7.2/animate.min.css">
+		<link rel="stylesheet" type="text/css" href="{{ mix('/css/app-tailwind.css') }}" />
 		<link rel="stylesheet" type="text/css" href="{{ mix('/css/style.css') }}" />
 		{!! Html::style('css/magnific-popup.css') !!}
 		@livewireStyles

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,13 +4,13 @@ module.exports = {
     "./resources/**/*.js",
     "./resources/**/*.vue",
   ],
-  important: '#tailwind-rules',
+  important: '.tailwind-rules',
   theme: {
     extend: {},
   },
   plugins: [],
   prefix: 'tw-',
   corePlugins: {
-    preflight: false, // TODO re-enable after switching from Bootstrap
+    preflight: false, // TODO Not needed. Re-enable after switching from Bootstrap
   }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,16 @@
+module.exports = {
+  content: [
+    "./resources/**/*.blade.php",
+    "./resources/**/*.js",
+    "./resources/**/*.vue",
+  ],
+  important: '#tailwind-rules',
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+  prefix: 'tw-',
+  corePlugins: {
+    preflight: false, // TODO re-enable after switching from Bootstrap
+  }
+}

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -43,6 +43,9 @@ mix
     // CSS
     .less('resources/less/admin.less', 'public/css')
     .less('resources/less/style.less', 'public/css')
+    .postCss("resources/css/app-tailwind.css", "public/css", [
+        require("tailwindcss")
+    ])
 
     // E-mail themes are expected in resources/ but Mix does not save outside of public/
     // https://github.com/laravel-mix/laravel-mix/issues/1228


### PR DESCRIPTION
@igor-kamil @rastislav-chynoransky 
While working on the new homepage, it occurred to me that we could probably already be using Tailwind on new pages.

I've put together a config that I think will work alongside the current Bootstrap set-up as long as we:

- use a `tw-` prefix for Tailwind classes (this works even with IDE completion): https://tailwindcss.com/docs/configuration#prefix
- keep new pages/component within `.tailwind-rules` classes (https://tailwindcss.com/docs/configuration#important). This is because we have to disable certain defaults e.g. for headings (see app-tailwind.css).

So this proposed setup not ideal, but it is something that would allow us to use Tailwind today without committing to a full-on migration.

I've deployed https://test.webumenia.sk/new-home so that you can see this in action. Right now this adds ~3KB to our bundle.