### PR TITLE
fix cs translation file for authority filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file[^1].
 
 ## [Unreleased]
 
+## [2.42.1] - 2022-01-30
+### Fixed
+- broken authors page in czech language
+
 ## [2.42.0] - 2022-01-28
 ### Added
 - filter catalog by curator and fix harvesting of curator data

--- a/resources/lang/cs/authority.php
+++ b/resources/lang/cs/authority.php
@@ -39,12 +39,12 @@ return array(
         'role' => 'role',
         'nationality' => 'příslušnost',
         'place' => 'místo',
+        'sex' => 'pohlaví',
         'title_generator' => [
             'first_letter' => 'začíná se na: :value',
             'role' => 'role: :value',
             'nationality' => 'příslušnost: :value',
             'place' => 'místo: :value',
-            'sex' => 'pohlaví',
             'years' => 'v letech :from — :to',
         ],
         'sort_by' => 'podle',


### PR DESCRIPTION
# Description

missing translation string caused `htmlspecialchars() expects parameter 1 to be string, array given` in czech variant for https://www.webumenia.sk/cs/autori


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have updated the [CHANGELOG](../CHANGELOG.md)
- [ ] I have requested at least 1 reviewer for this PR
- [ ] I have made corresponding changes to the documentation
