### PR TITLE
Hotfix/webumenia 1775 reproduction order without frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file[^1].
 
 ## [Unreleased]
 
+## [2.42.2] - 2022-01-31
+### Fixed
+- JIRA request in order process
+
 ## [2.42.1] - 2022-01-30
 ### Fixed
 - broken authors page in czech language

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file[^1].
 
 ## [2.42.2] - 2022-01-31
 ### Fixed
-- JIRA request in order process
+- always fill in purpose in JIRA request in order
+- diacritic in frame variants in order form
 
 ## [2.42.1] - 2022-01-30
 ### Fixed

--- a/resources/views/objednavka.blade.php
+++ b/resources/views/objednavka.blade.php
@@ -178,7 +178,7 @@
 <div id="for_frame">
     {!! Former::select('frame')->label(trans('objednavka.form_frame'))->required()->options(array(
             trans('objednavka.form_frame_black') => array('value'=>'čierny'),
-            trans('objednavka.form_frame_white') => array('value'=>'svetly'),
+            trans('objednavka.form_frame_white') => array('value'=>'svetlý'),
     ))->help('<a href="#" class="underline" data-toggle="modal" data-target="#previewFrames"><i class="fa fa-info-circle"></i> '.trans('objednavka.form_frame_help').'</a>'); !!}
 </div>
 <div id="for_printed">

--- a/routes/web.php
+++ b/routes/web.php
@@ -157,6 +157,13 @@ function()
             }
 
             $type = (Request::input('format') == 'digitálna reprodukcia') ? 'digitálna' : 'tlačená';
+            $purpose = ($order->purpose) ? $order->purpose : $order->frame;
+
+            // @TODO: remove this after EEA fix accepting empty purpose
+            if (empty($purpose)) {
+                $purpose =  'účel';
+            }
+            // /@TODO
 
             //poslat objednavku do Jiry
             $client = new GuzzleHttp\Client();
@@ -168,7 +175,7 @@ function()
                     'contactPerson' => $order->name,
                     'email' => $order->email,
                     'kindOfPurpose' => $order->purpose_kind,
-                    'purpose' => $order->purpose."\n".$order->frame,
+                    'purpose' => $purpose,
                     'medium' => 'Iné',
                     'address' => $order->address,
                     'phone' => $order->phone,


### PR DESCRIPTION
# Description

temporary fix to always fill in `purpose` which started to be required attribute in endpoint for creating order
+ fix diacritic in frame variant

https://jira.sng.sk/browse/WEBUMENIA-1775

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have updated the [CHANGELOG](../CHANGELOG.md)
- [ ] I have requested at least 1 reviewer for this PR
- [ ] I have made corresponding changes to the documentation
