### PR TITLE
Disable success notifications in Mix

### DIFF
--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -46,7 +46,8 @@ mix
     .postCss('resources/css/app-tailwind.css', 'public/css', [
         require('tailwindcss')
     ])
-
+    
+    .disableSuccessNotifications()
     .options({
         processCssUrls: !process.env.MIX_SKIP_CSS_URL_PROCESSING
     });


### PR DESCRIPTION
Because working with Tailwind's JIT compiler, there are a lot of them

https://laravel-mix.com/docs/6.0/os-notifications
