### PR TITLE
Fix homepage carousel not showing subtitle/excerpt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file[^1].
 
 ## [Unreleased]
+### Fixed
+- homepage carousel not showing subtitle/excerpt
 
 ## [2.44.0] - 2022-02-01
 ### Added

--- a/resources/views/intro.blade.php
+++ b/resources/views/intro.blade.php
@@ -38,14 +38,14 @@
             <a href="{!! $slide->url !!}" class="outer-box" data-id="{!! $slide->id !!}" >
                 <div class="inner-box-shadow" >
                     <h1>{!! $slide->title !!}</h1>
-                    @if ($slide->subtitle)
-                        <h2>{!! $slide->subtitle !!}</h2>
+                    @if ($slide->excerpt)
+                        <h2>{!! $slide->excerpt !!}</h2>
                     @endif
                 </div>
                 <div class="inner-box">
                     <h1>{!! $slide->title !!}</h1>
-                    @if ($slide->subtitle)
-                        <h2>{!! $slide->subtitle !!}</h2>
+                    @if ($slide->excerpt)
+                        <h2>{!! $slide->excerpt !!}</h2>
                     @endif
                 </div>
             </a>


### PR DESCRIPTION
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have updated the [CHANGELOG](../CHANGELOG.md)
- [ ] I have requested at least 1 reviewer for this PR
- [ ] I have made corresponding changes to the documentation
