### PR TITLE
Bring 'file' cache in-line with original skeleton

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -44,7 +44,7 @@ return [
 
         'file' => [
             'driver' => 'file',
-            'path' => storage_path('framework/cache'),
+            'path' => storage_path('framework/cache/data'),
         ],
 
         'memcached' => [


### PR DESCRIPTION
Otherwise storage/framework/cache/data/.gitignore gets removed with `php artisan cache:clear`