### PR TITLE
Unset global a:hover a:focus styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file[^1].
  
 ### Fixed
 - some styling issues with new Openseadragon
+- disabled global Bootstrap `<a>` styles 
 
 ## [2.47.0] - 2022-03-11
 ### Added

--- a/resources/css/app-tailwind.css
+++ b/resources/css/app-tailwind.css
@@ -16,12 +16,6 @@
         transition: unset;
     }
 
-    .tailwind-rules a:hover,
-    .tailwind-rules a:focus {
-        @apply tw-decoration-inherit;
-        color: initial;
-    }
-
     /* Theme defaults */
     /* Once Bootstrap is removed, the applied classes here can be moved to <body> */
     .tailwind-rules {

--- a/resources/css/app-tailwind.css
+++ b/resources/css/app-tailwind.css
@@ -13,7 +13,7 @@
     }
 
     .tailwind-rules a {
-        transition: unset;
+        transition: inherit;
     }
 
     /* Theme defaults */

--- a/resources/less/bootstrap/scaffolding.less
+++ b/resources/less/bootstrap/scaffolding.less
@@ -49,15 +49,16 @@ a {
   color: @link-color;
   text-decoration: none;
 
-  &:hover,
-  &:focus {
-    color: @link-hover-color;
-    text-decoration: @link-hover-decoration;
-  }
+  // Hover & focus global styles disabled to enable Tailwind CSS integration
+  // &:hover,
+  // &:focus {
+  //   color: @link-hover-color;
+  //   text-decoration: @link-hover-decoration;
+  // }
 
-  &:focus {
-    .tab-focus();
-  }
+  // &:focus {
+  //   .tab-focus();
+  // }
 }
 
 

--- a/resources/less/custom.less
+++ b/resources/less/custom.less
@@ -128,12 +128,6 @@ a {
 }
 
 
-a:hover,
-a:focus {
-    text-decoration: none;
-    color: @primary;
-}
-
 // Non-production Alert
 #alert-non-production {
   margin: 0;


### PR DESCRIPTION
This change removes all global (unscoped) `a:hover` and `a:focus` styles that have been introduced by either Bootstrap or our own CSS. I could not find any other way to re-set these styles in a scoped CSS so that we could use Tailwind reliably (within `.tailwind-rules`).

This is potentially a breaking change, but I've tested links on all pages I could think of and did not find this change to have any effect -- `<a>` tags in the wild are usually overriden within other scopes.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have updated the [CHANGELOG](../CHANGELOG.md)
- [x] I have requested at least 1 reviewer for this PR
- [ ] I have made corresponding changes to the documentation
