### PR TITLE
Release/2.48.0

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -2,5 +2,6 @@
     "tabWidth": 4,
     "printWidth": 100,
     "singleQuote": true,
+    "semi": false,
     "sortTailwindcssClasses": true
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file[^1].
 
 ## [Unreleased]
+
+## [2.48.0] - 2022-03-25
 ### Added
 - global word-break:keep-all
 - "counts blurb" to new homepage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file[^1].
 ## [Unreleased]
 ### Added
 - global word-break:keep-all
+- "counts blurb" to new homepage
 
 ### Changed
 - resolve api route name conflicts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file[^1].
  
 ### Fixed
 - some styling issues with new Openseadragon
+- disabled global Bootstrap `<a>` styles 
 
 ## [2.47.0] - 2022-03-11
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,12 @@ All notable changes to this project will be documented in this file[^1].
 ## [Unreleased]
 ### Added
 - global word-break:keep-all
+
 ### Changed
 - resolve api route name conflicts
+ 
+### Fixed
+- some styling issues with new Openseadragon
 
 ## [2.47.0] - 2022-03-11
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file[^1].
 ## [Unreleased]
 ### Added
 - global word-break:keep-all
+### Changed
+- resolve api route name conflicts
 
 ## [2.47.0] - 2022-03-11
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file[^1].
 
 ## [Unreleased]
+### Added
+- global word-break:keep-all
 
 ## [2.47.0] - 2022-03-11
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file[^1].
 ### Added
 - global word-break:keep-all
 - "counts blurb" to new homepage
+- performance tweaks to new homepage
 
 ### Changed
 - resolve api route name conflicts

--- a/app/Article.php
+++ b/app/Article.php
@@ -1,7 +1,5 @@
 <?php
 
-
-
 namespace App;
 
 use App\Concerns\HasHeaderImage;
@@ -33,15 +31,9 @@ class Article extends Model implements TranslatableContract
 
     public $translatedAttributes = ['title', 'summary', 'content'];
 
-    protected $fillable = [
-        'published_date',
-    ];
+    protected $fillable = ['published_date'];
 
-    protected $dates = [
-        'created_at',
-        'updated_at',
-        'published_date'
-    ];
+    protected $dates = ['created_at', 'updated_at', 'published_date'];
 
     protected $casts = [
         'edu_media_types' => 'array',
@@ -60,13 +52,7 @@ class Article extends Model implements TranslatableContract
         'activities',
     ];
 
-    public static $eduAgeGroups = [
-        'all-ages',
-        '3-6',
-        '7-10',
-        '11-15',
-        '16-19',
-    ];
+    public static $eduAgeGroups = ['all-ages', '3-6', '7-10', '11-15', '16-19'];
 
     public static function getValidationRules()
     {
@@ -111,17 +97,17 @@ class Article extends Model implements TranslatableContract
         $string = strip_tags($string);
         $string = $string;
         $string = substr($string, 0, $length);
-        return substr($string, 0, strrpos($string, ' ')) . " ...";
+        return substr($string, 0, strrpos($string, ' ')) . ' ...';
     }
 
     public function getTitleColorAttribute($value)
     {
-        return (!empty($value)) ? $value : '#fff';
+        return !empty($value) ? $value : '#fff';
     }
 
     public function getTitleShadowAttribute($value)
     {
-        return (!empty($value)) ? $value : '#777';
+        return !empty($value) ? $value : '#777';
     }
 
     public function scopePublished($query)
@@ -131,10 +117,7 @@ class Article extends Model implements TranslatableContract
 
     public function getContentImages()
     {
-        return array_merge(
-            parseUrls($this->summary),
-            parseUrls($this->content)
-        );
+        return array_merge(parseUrls($this->summary), parseUrls($this->content));
     }
 
     public function scopePromoted($query)
@@ -149,10 +132,11 @@ class Article extends Model implements TranslatableContract
             $this->attributes['published_date'] = $current_time->toDateTimeString();
         }
 
-        $this->attributes['publish'] = (bool)$value;
+        $this->attributes['publish'] = (bool) $value;
     }
 
-    public function getReadingTimeAttribute(){
+    public function getReadingTimeAttribute()
+    {
         return getEstimatedReadingTime($this->summary . ' ' . $this->content, \App::getLocale());
     }
 }

--- a/app/Article.php
+++ b/app/Article.php
@@ -10,6 +10,7 @@ use Astrotomic\Translatable\Translatable;
 use Illuminate\Support\Facades\URL;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Validation\Rule;
 
 class Article extends Model implements TranslatableContract
@@ -19,6 +20,11 @@ class Article extends Model implements TranslatableContract
     use \Conner\Tagging\Taggable;
 
     use HasHeaderImage;
+
+    protected static function booted()
+    {
+        static::saved(fn() => Cache::forget('home.articles'));
+    }
 
     function getArtworksDirAttribute()
     {

--- a/app/Collection.php
+++ b/app/Collection.php
@@ -9,6 +9,7 @@ use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Query\JoinClause;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\URL;
 
 class Collection extends Model implements TranslatableContract
@@ -16,6 +17,11 @@ class Collection extends Model implements TranslatableContract
     use Translatable;
 
     use HasHeaderImage;
+
+    protected static function booted()
+    {
+        static::saved(fn() => Cache::forget('home.collections'));
+    }
 
     function getArtworksDirAttribute()
     {

--- a/app/Collection.php
+++ b/app/Collection.php
@@ -28,28 +28,26 @@ class Collection extends Model implements TranslatableContract
         return '/images/kolekcie/';
     }
 
-    public $translatedAttributes = ['name','type', 'text'];
+    public $translatedAttributes = ['name', 'type', 'text'];
 
-    public static $rules = array(
+    public static $rules = [
         'sk.name' => 'required',
         'sk.text' => 'required',
-    );
+    ];
 
-    public static $sortable = array(
+    public static $sortable = [
         'published_at' => 'sortable.published_at',
         'updated_at' => 'sortable.updated_at',
-        'name'       => 'sortable.title',
-    );
+        'name' => 'sortable.title',
+    ];
 
-    protected $dates = array(
-        'created_at',
-        'updated_at',
-        'published_at'
-    );
+    protected $dates = ['created_at', 'updated_at', 'published_at'];
 
     public function items()
     {
-        return $this->belongsToMany(\App\Item::class, 'collection_item', 'collection_id', 'item_id')->withPivot('order')->orderBy('order', 'asc');
+        return $this->belongsToMany(\App\Item::class, 'collection_item', 'collection_id', 'item_id')
+            ->withPivot('order')
+            ->orderBy('order', 'asc');
     }
 
     public function user()
@@ -59,8 +57,9 @@ class Collection extends Model implements TranslatableContract
 
     public function getPreviewItems()
     {
-
-        return $this->items()->limit(10)->get();
+        return $this->items()
+            ->limit(10)
+            ->get();
     }
 
     public function getUrl()
@@ -73,7 +72,9 @@ class Collection extends Model implements TranslatableContract
         $striped_string = strip_tags(br2nl($string));
         $string = $striped_string;
         $string = substr($string, 0, $length);
-        return ($striped_string > $string) ? substr($string, 0, strrpos($string, ' ')) . " ..." : $string;
+        return $striped_string > $string
+            ? substr($string, 0, strrpos($string, ' ')) . ' ...'
+            : $string;
     }
 
     public function getContentImages()
@@ -88,12 +89,12 @@ class Collection extends Model implements TranslatableContract
 
     public function getTitleColorAttribute($value)
     {
-        return (!empty($value)) ? $value : '#fff';
+        return !empty($value) ? $value : '#fff';
     }
 
     public function getTitleShadowAttribute($value)
     {
-        return (!empty($value)) ? $value : '#777';
+        return !empty($value) ? $value : '#777';
     }
 
     public function scopeOrderByTranslation(Builder $query, $column, $dir = 'asc', $locale = null)
@@ -102,7 +103,8 @@ class Collection extends Model implements TranslatableContract
 
         return $query
             ->join('collection_translations as t', function ($join) use ($locale) {
-                $join->on('collections.id', '=', 't.collection_id')
+                $join
+                    ->on('collections.id', '=', 't.collection_id')
                     ->where(function ($query) use ($locale) {
                         $query->where('t.locale', '=', $locale);
 
@@ -122,9 +124,14 @@ class Collection extends Model implements TranslatableContract
         return $query->orWhere(function ($query) use ($locale, $alias) {
             $query->where("$alias.locale", '=', $this->getFallbackLocale());
 
-            $withTranslation = self::whereHas('translations', function (Builder $q) use ($locale, $alias) {
+            $withTranslation = self::whereHas('translations', function (Builder $q) use (
+                $locale,
+                $alias
+            ) {
                 $q->where($this->getLocaleKey(), '=', $locale);
-            })->pluck('id')->toArray();
+            })
+                ->pluck('id')
+                ->toArray();
 
             if ($withTranslation) {
                 $query->whereNotIn("$alias.collection_id", $withTranslation);
@@ -132,7 +139,8 @@ class Collection extends Model implements TranslatableContract
         });
     }
 
-    public function getReadingTimeAttribute(){
-        return getEstimatedReadingTime($this->text, \App::getLocale() );
+    public function getReadingTimeAttribute()
+    {
+        return getEstimatedReadingTime($this->text, \App::getLocale());
     }
 }

--- a/app/FeaturedArtwork.php
+++ b/app/FeaturedArtwork.php
@@ -4,9 +4,15 @@ namespace App;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Cache;
 
 class FeaturedArtwork extends Model
 {
+    protected static function booted()
+    {
+        static::saved(fn() => Cache::forget('home.featured-artwork'));
+    }
+
     protected $fillable = [
         'is_published',
         'item',

--- a/app/FeaturedArtwork.php
+++ b/app/FeaturedArtwork.php
@@ -13,26 +13,26 @@ class FeaturedArtwork extends Model
         static::saved(fn() => Cache::forget('home.featured-artwork'));
     }
 
-    protected $fillable = [
-        'is_published',
-        'item',
-        'item_id',
-        'title',
-        'description',
-    ];
+    protected $fillable = ['is_published', 'item', 'item_id', 'title', 'description'];
 
     public function item()
     {
         return $this->belongsTo(Item::class);
     }
 
-    public function getIsPublishedAttribute() {
+    public function getIsPublishedAttribute()
+    {
         return !!$this->published_at;
     }
 
-    public function setIsPublishedAttribute(bool $isPublished) {
-        if ($this->is_published === $isPublished) return;
-        if (!$isPublished) return $this->attributes['published_at'] = null;
+    public function setIsPublishedAttribute(bool $isPublished)
+    {
+        if ($this->is_published === $isPublished) {
+            return;
+        }
+        if (!$isPublished) {
+            return $this->attributes['published_at'] = null;
+        }
 
         $this->attributes['published_at'] = Carbon::now();
     }
@@ -44,37 +44,44 @@ class FeaturedArtwork extends Model
 
     public function getAuthorLinksAttribute()
     {
-        if (!$this->item) return;
+        if (!$this->item) {
+            return;
+        }
 
-        return $this->item
-        ->authors_with_authorities
-        ->map(fn ($a) => (object) [
-            'label' => formatName($a->name),
-            'url' => isset($a->authority) ? $a->authority->getUrl() : route('frontend.catalog.index', ['author' => $a->name])
-        ]);
+        return $this->item->authors_with_authorities->map(
+            fn($a) => (object) [
+                'label' => formatName($a->name),
+                'url' => isset($a->authority)
+                    ? $a->authority->getUrl()
+                    : route('frontend.catalog.index', ['author' => $a->name]),
+            ]
+        );
     }
 
     public function getMetadataLinksAttribute()
     {
-        if (!$this->item) return;
+        if (!$this->item) {
+            return;
+        }
 
         $dating = (object) [
             'label' => $this->item->getDatingFormated(),
             'url' => null,
         ];
 
-        $techniques = collect($this->item->techniques)
-            ->map(fn ($t) => (object) [
+        $techniques = collect($this->item->techniques)->map(
+            fn($t) => (object) [
                 'label' => $t,
                 'url' => route('frontend.catalog.index', ['technique' => $t]),
-            ]);
+            ]
+        );
 
-        $media = collect($this->item->mediums)
-            ->map(fn ($m) => (object) [
+        $media = collect($this->item->mediums)->map(
+            fn($m) => (object) [
                 'label' => $m,
                 'url' => route('frontend.catalog.index', ['medium' => $m]),
-            ]);
-
+            ]
+        );
 
         return collect([$dating])
             ->concat($techniques)

--- a/app/FeaturedPiece.php
+++ b/app/FeaturedPiece.php
@@ -17,13 +17,7 @@ class FeaturedPiece extends Model implements HasMedia
         static::saved(fn() => Cache::forget('home.featured-piece'));
     }
 
-    protected $fillable = [
-        'title',
-        'excerpt',
-        'url',
-        'publish',
-        'type',
-    ];
+    protected $fillable = ['title', 'excerpt', 'url', 'publish', 'type'];
 
     public static $rules = [
         'title' => 'required',
@@ -55,8 +49,7 @@ class FeaturedPiece extends Model implements HasMedia
 
     public function registerMediaCollections(): void
     {
-        $this
-            ->addMediaCollection('image')
+        $this->addMediaCollection('image')
             ->singleFile()
             ->withResponsiveImages();
     }

--- a/app/FeaturedPiece.php
+++ b/app/FeaturedPiece.php
@@ -3,6 +3,7 @@
 namespace App;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Cache;
 use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\InteractsWithMedia;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
@@ -10,6 +11,11 @@ use Spatie\MediaLibrary\MediaCollections\Models\Media;
 class FeaturedPiece extends Model implements HasMedia
 {
     use InteractsWithMedia;
+
+    protected static function booted()
+    {
+        static::saved(fn() => Cache::forget('home.featured-piece'));
+    }
 
     protected $fillable = [
         'title',

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -10,51 +10,92 @@ use App\FeaturedArtwork;
 use App\FeaturedPiece;
 use App\Filter\ItemFilter;
 use App\Item;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Cache;
 
 class HomeController extends Controller
 {
     public function index()
     {
-        // TODO caching
-        $featuredPiece = FeaturedPiece::query()
-            ->published()
-            ->with('media')
-            ->orderBy('updated_at', 'desc')
-            ->first();
+        $featuredPiece = Cache::rememberForever('home.featured-piece', function () {
+            return FeaturedPiece::query()
+                ->published()
+                ->with('media')
+                ->orderBy('updated_at', 'desc')
+                ->first();
+        });
 
-        $featuredArtwork = FeaturedArtwork::query()
-            ->published()
-            ->orderBy('updated_at', 'desc')
-            ->first();
+        $featuredArtwork = Cache::rememberForever('home.featured-artwork', function () {
+            return FeaturedArtwork::query()
+                ->with(['item.authorities', 'item.translations'])
+                ->published()
+                ->orderBy('updated_at', 'desc')
+                ->first();
+        });
 
-        $featuredAuthor = Authority::query()
-            ->where('has_image', true)
-            ->where('type', 'person')
-            ->has('items', '>', 3)
-            ->inRandomOrder()
-            ->first();
+        [$featuredAuthor, $featuredAuthorItems] = Cache::remember(
+            'home.featured-author',
+            now()->addDays(7),
+            function () {
+                $author = Authority::query()
+                    ->with(['translations'])
+                    ->withCount('items')
+                    ->where('has_image', true)
+                    ->where('type', 'person')
+                    ->whereHas(
+                        'items',
+                        function (Builder $query) {
+                            $query->has('images');
+                        },
+                        '>=',
+                        3
+                    )
+                    ->inRandomOrder()
+                    ->first();
 
-        $articles = Article::query()
-            ->with(['translations', 'category'])
-            ->published()
-            ->orderBy('published_date', 'desc')
-            ->limit(5)
-            ->get();
+                $items = $author
+                    ->items()
+                    ->has('images')
+                    ->inRandomOrder()
+                    ->limit(10)
+                    ->get();
 
-        $articlesTotalCount = Article::published()->count();
-        $articlesRemainingCount = floor(($articlesTotalCount - 5) / 10) * 10; // Round down to nearest 10
+                return [$author, $items];
+            }
+        );
 
-        $collections = Collection::query()
-            ->with(['translations', 'user'])
-            ->withCount('items')
-            ->published()
-            ->orderBy('published_at', 'desc')
-            ->take(5)
-            ->get();
+        [$articles, $articlesRemainingCount] = Cache::rememberForever('home.articles', function () {
+            $articles = Article::query()
+                ->with(['translations', 'category'])
+                ->published()
+                ->orderBy('published_date', 'desc')
+                ->limit(5)
+                ->get();
 
-        $collectionsTotalCount = Collection::published()->count();
-        $collectionsRemainingCount = floor(($collectionsTotalCount - 5) / 10) * 10; // Round down to nearest 10
+            $totalCount = Article::published()->count();
+            $remainingCount = floor(($totalCount - 5) / 10) * 10; // Round down to nearest 10
+
+            return [$articles, $remainingCount];
+        });
+
+        [$collections, $collectionsRemainingCount] = Cache::rememberForever(
+            'home.collections',
+            function () {
+                $collections = Collection::query()
+                    ->with(['translations', 'user'])
+                    ->withCount('items')
+                    ->published()
+                    ->orderBy('published_at', 'desc')
+                    ->take(5)
+                    ->get();
+
+                $totalCount = Collection::published()->count();
+                $remainingCount = floor(($totalCount - 5) / 10) * 10; // Round down to nearest 10
+
+                return [$collections, $remainingCount];
+            }
+        );
+
         $countsBlurb = $this->getCountsBlurbData();
 
         return view('home.index')->with(
@@ -62,6 +103,7 @@ class HomeController extends Controller
                 'featuredPiece',
                 'featuredArtwork',
                 'featuredAuthor',
+                'featuredAuthorItems',
                 'articles',
                 'articlesRemainingCount',
                 'collections',

--- a/config/cache.php
+++ b/config/cache.php
@@ -44,7 +44,7 @@ return [
 
         'file' => [
             'driver' => 'file',
-            'path' => storage_path('framework/cache'),
+            'path' => storage_path('framework/cache/data'),
         ],
 
         'memcached' => [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1175,12 +1175,12 @@
             }
         },
         "@shufo/prettier-plugin-blade": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@shufo/prettier-plugin-blade/-/prettier-plugin-blade-1.1.4.tgz",
-            "integrity": "sha512-xT0Yd90cQAtm686fua13c3Gs3vzVBA4mYGrgLv5S8meg/W/U5rDC0rajxobmv71cXnqdYOpzE8rMuYd7RKDzCg==",
+            "version": "1.1.8",
+            "resolved": "https://registry.npmjs.org/@shufo/prettier-plugin-blade/-/prettier-plugin-blade-1.1.8.tgz",
+            "integrity": "sha512-dy7JA1NORK5GgQcirHn1TjHUy3BCD9y3UZlgJttVl89cNMZQexLf4rV72kKkU8EC7Lf3DZBLgFmS2CFMYLrTsA==",
             "dev": true,
             "requires": {
-                "blade-formatter": "^1.20.5",
+                "blade-formatter": "^1.21.3",
                 "prettier": "^2.5.1",
                 "synckit": "^0.6.0"
             }
@@ -2501,9 +2501,9 @@
             }
         },
         "blade-formatter": {
-            "version": "1.20.5",
-            "resolved": "https://registry.npmjs.org/blade-formatter/-/blade-formatter-1.20.5.tgz",
-            "integrity": "sha512-4fJUuir76Rok0YP1J+i3vrDUYfu6KB3x8u7THnP6llAHTnRm44k2gpgp3wQrikmaYxBdIOIT3EZ4esa3zATwoQ==",
+            "version": "1.21.3",
+            "resolved": "https://registry.npmjs.org/blade-formatter/-/blade-formatter-1.21.3.tgz",
+            "integrity": "sha512-xddv5vHYwF2x2PVRvuTLIu4oy+nleFcM+7sROW6AEuCNOY6/CXt7DJvSIb58OUZHgZr1/Wt+fvfsvqH7JPXxug==",
             "dev": true,
             "requires": {
                 "@prettier/plugin-php": "^0.18.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     },
     "devDependencies": {
         "@prettier/plugin-php": "^0.18.2",
-        "@shufo/prettier-plugin-blade": "^1.1.4",
+        "@shufo/prettier-plugin-blade": "^1.1.8",
         "autoprefixer": "^10.4.2",
         "cross-env": "^5.1",
         "jquery": "^3.5.0",

--- a/public/images/collection-items-count.svg
+++ b/public/images/collection-items-count.svg
@@ -1,5 +1,0 @@
-<svg viewBox="0 0 106 28" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg" fill="transparent">
-    <path d="M100 23.1818V26C100 26.5523 99.5523 27 99 27H2C1.44772 27 1 26.5523 1 26V7C1 6.44772 1.44772 6 2 6H4" stroke="black" />
-    <rect x="4" width="98" height="20" rx="1" fill="black" fill-opacity="0.6" />
-    <path d="M102 4H104C104.552 4 105 4.44772 105 5V22C105 22.5523 104.552 23 104 23H8C7.44771 23 7 22.5523 7 22V20.15" stroke="black" />
-</svg>

--- a/public/js/components/zoomviewer.js
+++ b/public/js/components/zoomviewer.js
@@ -83,6 +83,17 @@ $("document").ready(function() {
 
     viewer = OpenSeadragon(OSDOptions);
 
+    viewer.addHandler('open', function (event) {
+      const referenceStrip = event.eventSource.referenceStrip;
+      if (!referenceStrip) return;
+
+      // Highlight selected referenceStrip panel
+      $(referenceStrip.panels).each(function () {
+        $(this).removeClass('selected');
+      });
+      $(referenceStrip.currentSelected).addClass('selected');
+    });
+
     viewer.addHandler('page', function (event) {
       isLoaded = false;
       $('.currentpage #index').html( event.page + 1 );

--- a/resources/css/app-tailwind.css
+++ b/resources/css/app-tailwind.css
@@ -16,12 +16,6 @@
         transition: unset;
     }
 
-    .tailwind-rules a:hover,
-    .tailwind-rules a:focus {
-        @apply tw-decoration-inherit;
-        color: initial;
-    }
-
     /* Theme defaults */
     /* Once Bootstrap is removed, the applied classes here can be moved to <body> */
     .tailwind-rules {

--- a/resources/css/app-tailwind.css
+++ b/resources/css/app-tailwind.css
@@ -20,8 +20,9 @@
     /* Theme defaults */
     /* Once Bootstrap is removed, the applied classes here can be moved to <body> */
     .tailwind-rules {
-        @apply tw-text-base tw-text-gray-800 tw-font-sans;
+        @apply keep-all tw-text-base tw-text-gray-800 tw-font-sans;
     }
+
     .tailwind-rules.admin {
         @apply tw-text-sm;
         font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
@@ -31,5 +32,9 @@
 @layer utilities {
     [v-cloak] {
         @apply tw-hidden;
+    }
+
+    .keep-all {
+        word-break: keep-all;
     }
 }

--- a/resources/css/app-tailwind.css
+++ b/resources/css/app-tailwind.css
@@ -13,7 +13,7 @@
     }
 
     .tailwind-rules a {
-        transition: unset;
+        transition: inherit;
     }
 
     /* Theme defaults */

--- a/resources/css/app-tailwind.css
+++ b/resources/css/app-tailwind.css
@@ -12,9 +12,14 @@
         font-size: 16px !important;
     }
 
+    .tailwind-rules a {
+        transition: unset;
+    }
+
     .tailwind-rules a:hover,
     .tailwind-rules a:focus {
-        @apply tw-text-inherit tw-decoration-inherit;
+        @apply tw-decoration-inherit;
+        color: initial;
     }
 
     /* Theme defaults */

--- a/resources/js/components/Flickity.vue
+++ b/resources/js/components/Flickity.vue
@@ -14,11 +14,12 @@
 </template>
 
 <script>
-import Flickity from "flickity-imagesloaded"
+import Flickity from 'flickity-imagesloaded'
 
 export default {
     props: {
         options: Object,
+        viewportClass: String,
 
         // Call resize() on Flickity instance when this prop changes to true for the first time.
         // Useful when Flickity is initialized hidden
@@ -38,12 +39,16 @@ export default {
                 ready() {
                     vm.slides = this.slides
                     vm.selectedIndex = this.selectedIndex
+
+                    if (vm.viewportClass) {
+                        this.viewport.classList.add(...vm.viewportClass.split(' '))
+                    }
                 },
                 change(index) {
                     vm.selectedIndex = index
-                }
+                },
             },
-            ...this.options
+            ...this.options,
         })
     },
     methods: {

--- a/resources/less/bootstrap/scaffolding.less
+++ b/resources/less/bootstrap/scaffolding.less
@@ -49,15 +49,16 @@ a {
   color: @link-color;
   text-decoration: none;
 
-  &:hover,
-  &:focus {
-    color: @link-hover-color;
-    text-decoration: @link-hover-decoration;
-  }
+  // Hover & focus global styles disabled to enable Tailwind CSS integration
+  // &:hover,
+  // &:focus {
+  //   color: @link-hover-color;
+  //   text-decoration: @link-hover-decoration;
+  // }
 
-  &:focus {
-    .tab-focus();
-  }
+  // &:focus {
+  //   .tab-focus();
+  // }
 }
 
 

--- a/resources/less/components/zoom-viewer.less
+++ b/resources/less/components/zoom-viewer.less
@@ -64,7 +64,8 @@ body.template-zoom {
   .referencestrip {
     background: transparent !important;
     min-width: 50px !important;
-    
+    outline: none;
+
     & > div {
       background: rgba(255, 255, 255, 0.8) !important;
       min-width: 50px !important;

--- a/resources/less/custom.less
+++ b/resources/less/custom.less
@@ -46,6 +46,7 @@ body {
     height: 100%;
     color: @dark;
     background-color: @light;
+    word-break: keep-all;
 }
 
 html {
@@ -1021,5 +1022,3 @@ label sup {
     padding-left: unset;
   }
 }
-
-

--- a/resources/less/custom.less
+++ b/resources/less/custom.less
@@ -128,12 +128,6 @@ a {
 }
 
 
-a:hover,
-a:focus {
-    text-decoration: none;
-    color: @primary;
-}
-
 // Non-production Alert
 #alert-non-production {
   margin: 0;

--- a/resources/views/components/home/carousel.blade.php
+++ b/resources/views/components/home/carousel.blade.php
@@ -1,4 +1,4 @@
-@props(['imagesLoaded' => false])
+@props(['imagesLoaded' => false, 'buttonContainerClass' => ''])
 
 @php
 $options = [
@@ -11,23 +11,25 @@ $options = [
 ];
 @endphp
 
-<flickity
-    {{ $attributes->merge([
-        'class' => 'tw-relative',
-        'v-bind:options' => Illuminate\Support\Js::from($options),
-    ]) }}>
-    {{ $slot }}
-    <template v-slot:custom-ui="{ next, previous, selectedIndex, slides }">
-        <div
-            class="tw-absolute tw-inset-y-0 tw-inset-x-4 md:tw--inset-x-7 tw-flex tw-items-center tw-justify-between tw-pointer-events-none">
-            <button v-on:click="previous" v-bind:disabled="selectedIndex === 0"
-                class="tw-pointer-events-auto tw-rounded-full tw-bg-gray-300 tw-bg-opacity-60 hover:tw-bg-opacity-90 disabled:hover:tw-bg-opacity-60 disabled:tw-opacity-30 tw-transition tw-w-10 tw-h-10 sm:tw-w-14 sm:tw-h-14 tw-flex tw-items-center tw-justify-center tw-text-xl">
-                <i class="fa icon-arrow-left"></i>
-            </button>
-            <button v-on:click="next" v-bind:disabled="selectedIndex === slides.length - 1"
-                class="tw-pointer-events-auto tw-rounded-full tw-bg-gray-300 tw-bg-opacity-60 hover:tw-bg-opacity-90 disabled:hover:tw-bg-opacity-60 disabled:tw-opacity-30 tw-transition tw-w-10 tw-h-10 sm:tw-w-14 sm:tw-h-14 tw-flex tw-items-center tw-justify-center tw-text-xl">
-                <i class="fa icon-arrow-right"></i>
-            </button>
-        </div>
-    </template>
-</flickity>
+<div class="tw--mx-6 tw-overflow-hidden tw-px-6">
+    <flickity v-bind:options={{ Illuminate\Support\Js::from($options) }}
+        viewport-class="tw-overflow-visible xl:tw-overflow-hidden"
+        {{ $attributes->merge(['class' => 'tw-relative']) }}>
+        {{ $slot }}
+        <template v-slot:custom-ui="{ next, previous, selectedIndex, slides }">
+            <div class="tw-pointer-events-none tw-absolute tw-inset-y-0 tw--inset-x-5">
+                <div
+                    class="tw-flex tw-items-center tw-justify-between {{ $buttonContainerClass }}">
+                    <button v-on:click="previous" v-bind:disabled="selectedIndex === 0"
+                        class="tw-pointer-events-auto tw-flex tw-h-10 tw-w-10 tw-items-center tw-justify-center tw-rounded-full tw-bg-gray-300 tw-bg-opacity-60 tw-text-xl tw-transition hover:tw-bg-opacity-90 disabled:tw-opacity-30 disabled:hover:tw-bg-opacity-60">
+                        <i class="fa icon-arrow-left"></i>
+                    </button>
+                    <button v-on:click="next" v-bind:disabled="selectedIndex === slides.length - 1"
+                        class="tw-pointer-events-auto tw-flex tw-h-10 tw-w-10 tw-items-center tw-justify-center tw-rounded-full tw-bg-gray-300 tw-bg-opacity-60 tw-text-xl tw-transition hover:tw-bg-opacity-90 disabled:tw-opacity-30 disabled:hover:tw-bg-opacity-60">
+                        <i class="fa icon-arrow-right"></i>
+                    </button>
+                </div>
+            </div>
+        </template>
+    </flickity>
+</div>

--- a/resources/views/home/index.blade.php
+++ b/resources/views/home/index.blade.php
@@ -25,23 +25,24 @@
 
 @section('content')
     <div class="tailwind-rules">
-
         @if ($featuredPiece)
             <div class="tw-relative">
                 {{ $featuredPiece->image->img()->attributes(['class' => 'tw-object-cover tw-absolute tw-h-full tw-w-full', 'width' => null, 'height' => null]) }}
                 <div
-                    class="tw-absolute tw-inset-0 tw-bg-gradient-to-r tw-from-black/70 tw-to-black/40 md:tw-to-black/0">
+                    class="tw-absolute tw-inset-0 tw-bg-gradient-to-r tw-from-black/50 tw-to-black/20 md:tw-to-black/0">
                 </div>
                 <div
-                    class="tw-container tw-relative tw-mx-auto tw-max-w-screen-xl tw-px-6 tw-pt-60 tw-pb-8 tw-text-white md:tw-pb-20">
-                    <h2 class="tw-font-semibold md:tw-text-2xl">Odporúčame</h2>
-                    <h3 class="tw-mt-4 tw-text-3xl tw-font-semibold md:tw-mt-6 md:tw-text-6xl">
+                    class="tw-container tw-mx-auto tw-max-w-screen-xl tw-py-8 tw-px-6 tw-text-white md:tw-py-20">
+                    <h2 class="tw-mt-36 tw-font-semibold tw-drop-shadow md:tw-mt-48 md:tw-text-lg">
+                        Odporúčame</h2>
+                    <h3 class="tw-mt-4 tw-text-3xl tw-font-semibold tw-drop-shadow md:tw-text-6xl">
                         {{ $featuredPiece->title }}
                     </h3>
-                    <p class="tw-mt-5 tw-max-w-lg tw-font-serif tw-leading-relaxed md:tw-text-xl">
+                    <p
+                        class="tw-mt-5 tw-max-w-lg tw-font-serif tw-leading-relaxed tw-drop-shadow md:tw-text-xl">
                         {{ $featuredPiece->excerpt }}</p>
                     <a href="{{ $featuredPiece->url }}"
-                        class="tw-mt-3 tw-inline-block tw-border tw-border-gray-300 tw-px-4 tw-py-2 tw-text-sm tw-transition tw-duration-300 hover:tw-border-gray-400 hover:tw-bg-white hover:tw-text-gray-800 md:tw-mt-6">
+                        class="tw-relative tw-mt-3 tw-inline-block tw-border tw-border-gray-300 tw-px-4 tw-py-2 tw-text-sm tw-transition tw-duration-300 hover:tw-border-gray-400 hover:tw-bg-white hover:tw-text-gray-800 md:tw-mt-6">
                         {{ $featuredPiece->is_collection ? 'Prejsť na kolekciu' : 'Prejsť na článok' }}
                         <i class="fa icon-arrow-right tw-ml-2"></i>
                     </a>
@@ -49,18 +50,19 @@
             </div>
         @endif
         @if ($featuredArtwork)
-            <div class="tw-bg-gray-800 tw-py-8 tw-text-white lg:tw-py-16">
+            <div class="tw-bg-gray-800 tw-text-white">
                 <div
-                    class="tw-container tw-mx-auto tw-grid tw-max-w-screen-xl tw-px-6 lg:tw-grid-cols-2 lg:tw-gap-x-14">
+                    class="tw-container tw-mx-auto tw-grid tw-max-w-screen-xl tw-px-6 tw-py-8 md:tw-pt-20 md:tw-pb-16 lg:tw-grid-cols-2 lg:tw-gap-x-14">
                     <div class="tw-text-center lg:tw-order-1">
                         <a href="{{ route('dielo', ['id' => $featuredArtwork->item->id]) }}"
                             class="tw-inline-block">
                             <x-item_image :id="$featuredArtwork->item->id"
+                                alt="{{ $featuredArtwork->title }}"
                                 class="tw-max-h-80 lg:tw-max-h-[32rem]" />
                         </a>
                     </div>
                     <h2
-                        class="tw-mt-6 tw-mb-2 tw-font-semibold lg:tw-col-span-2 lg:tw-mt-0 lg:tw-mb-6 lg:tw-text-2xl">
+                        class="tw-mt-6 tw-mb-4 tw-font-semibold lg:tw-col-span-2 lg:tw-mt-0 lg:tw-text-lg">
                         Dielo dňa
                     </h2>
                     <div>
@@ -95,19 +97,21 @@
             </div>
         @endif
 
-        <div class="tw-container tw-mx-auto tw-max-w-screen-xl tw-px-6 tw-py-6">
-            <h2 class="tw-font-semibold md:tw-text-2xl">Nový obsah</h2>
+        <div class="tw-container tw-mx-auto tw-max-w-screen-xl tw-px-6 tw-py-8 md:tw-py-16">
+            <h2 class="tw-font-semibold md:tw-text-lg">Nový obsah</h2>
 
-            <tabs-controller v-cloak v-slot="{ activeIndex }">
+            <tabs-controller v-cloak v-slot="{ activeIndex }" class="tw-mt-4">
                 <div class="tw-flex tw-items-end">
-                    <div class="tw-mt-2 tw-flex tw-grow tw-space-x-4 md:tw-mt-4">
+                    <div class="tw-flex tw-grow tw-space-x-4">
                         @foreach (['Kolekcie', 'Články'] as $tab)
                             <tab v-slot="{ active }">
+                                {{-- blade-formatter-disable --}}
                                 <button
                                     :class="[
-                            'tw-transition-colors tw-font-semibold tw-text-2xl md:tw-text-4xl tw-underline tw-underline-offset-[5px] md:tw-underline-offset-8 tw-decoration-3',
-                            !active && 'tw-text-gray-300'
-                        ]">{{ $tab }}</button>
+                                        'tw-transition-colors tw-font-semibold tw-text-2xl md:tw-text-4xl',
+                                        !active && 'tw-text-gray-300 hover:tw-underline tw-underline-offset-[5px] md:tw-underline-offset-8 tw-decoration-[3px]'
+                                    ]">{{ $tab }}</button>
+                            {{-- blade-formatter-enable --}}
                             </tab>
                         @endforeach
                     </div>
@@ -130,49 +134,45 @@
                         </a>
                     </transition>
                 </div>
-                <div class="tw-mt-6 md:tw-mt-8">
+                <div class="tw-mt-6">
                     <tab-panel v-slot="{ active }" class="tw-relative">
-                        <x-home.carousel v-bind:resize-once="active">
+                        <x-home.carousel v-bind:resize-once="active"
+                            button-container-class="tw-h-48">
                             @foreach ($collections as $c)
-                                <div class="tw-w-72 tw-pr-4 md:tw-w-1/3 xl:tw-w-1/4">
-                                    <div class="tw-relative">
+                                <div class="tw-mr-4 tw-w-72 md:tw-w-[25rem]">
+                                    <div class="tw-relative tw-bg-sky-400">
                                         <a href="{{ route('frontend.collection.detail', $c->id) }}">
                                             <img src="{{ $c->getThumbnailImage() }}"
                                                 class="tw-h-48 tw-object-cover tw-transition-opacity tw-duration-300 hover:tw-opacity-80">
                                         </a>
 
                                         <div
-                                            class="tw-pointer-events-none tw-absolute tw-inset-0 tw-text-right">
-                                            <div class="tw-relative tw-m-4 tw-inline-block">
-                                                <img class="tw-absolute tw-inset-0"
-                                                    src="{{ asset('images/collection-items-count.svg') }}" />
-                                                <div class="px-3 tw-relative tw-text-sm tw-text-white">
-                                                    {{ $c->items_count }} diel v kolekcii
-                                                </div>
-                                            </div>
+                                            class="tw-pointer-events-none tw-absolute tw-right-6 tw-top-6 tw-rounded-sm tw-bg-black/60 tw-px-1.5 tw-text-right tw-text-sm tw-text-white">
+                                            {{ $c->items_count }} diel v kolekcii
                                         </div>
                                     </div>
+                                    <span class="tw-mt-4 tw-inline-block tw-text-sm tw-text-gray-600">
+                                        {{ Str::ucfirst($c->type ?? 'kolekcia') }}
+                                    </span>
                                     <h4
-                                        class="tw-mt-4 tw-truncate tw-text-lg tw-font-semibold tw-text-black">
-                                        <a href="{{ route('frontend.collection.detail', $c->id) }}">
+                                        class="tw-truncate tw-text-lg tw-font-semibold tw-leading-tight tw-text-black">
+                                        <a href="{{ route('frontend.collection.detail', $c->id) }}"
+                                            title="{{ $c->name }}">
                                             {{ $c->name }}
                                         </a>
                                     </h4>
                                     <div class="tw-mt-2 tw-truncate tw-text-sm tw-text-gray-600">
-                                        {{ $c->published_at->format('d. m. Y') }} ∙
-                                        {{ $c->user->name }}
+                                        <a
+                                            href="{{ route('frontend.collection.index', ['author' => $c->user->name]) }}">{{ $c->user->name }}</a>
+                                        ∙ {{ $c->published_at->format('d. m. Y') }}
                                     </div>
-                                    <span
-                                        class="tw-mt-2 tw-inline-block tw-bg-gray-200 tw-px-3 tw-py-1 tw-text-sm">
-                                        {{ Str::ucfirst($c->type ?? 'kolekcia') }}
-                                    </span>
                                 </div>
                             @endforeach
                             <div
-                                class="tw-flex tw-h-full tw-w-full tw-flex-col tw-justify-center tw-bg-gray-200 tw-text-center tw-text-xl tw-font-semibold tw-text-black md:tw-w-1/3 xl:tw-w-1/4">
+                                class="tw-flex tw-h-48 tw-w-72 tw-flex-col tw-justify-center tw-bg-gray-200 tw-text-center tw-text-xl tw-font-semibold tw-text-black md:tw-w-[25rem]">
                                 <p>Na Webe umenia je ďalších viac<br /> ako
                                     {{ $collectionsRemainingCount }} kolekcií</p>
-                                <a class="tw-mt-5 tw-underline tw-decoration-gray-300 tw-decoration-3 tw-underline-offset-4 hover:tw-decoration-current hover:tw-transition-colors"
+                                <a class="tw-mt-5 tw-underline tw-decoration-gray-300 tw-decoration-[3px] tw-underline-offset-4 hover:tw-decoration-current hover:tw-transition-colors"
                                     href="{{ route('frontend.collection.index') }}">Zobraziť ďalšie
                                     kolekcie</a>
                             </div>
@@ -180,34 +180,37 @@
                     </tab-panel>
 
                     <tab-panel v-slot="{ active }" class="tw-relative">
-                        <x-home.carousel v-bind:resize-once="active">
+                        <x-home.carousel v-bind:resize-once="active"
+                            button-container-class="tw-h-48">
                             @foreach ($articles as $a)
-                                <div class="tw-w-72 tw-pr-4 md:tw-w-1/3 xl:tw-w-1/4">
-                                    <a href="{{ route('frontend.article.detail', $a->slug) }}">
+                                <div class="tw-mr-4 tw-w-72 md:tw-w-[25rem]">
+                                    <a href="{{ route('frontend.article.detail', $a->slug) }}"
+                                        class="tw-block tw-bg-sky-400">
                                         <img src="{{ $a->getThumbnailImage() }}"
                                             class="tw-h-48 tw-object-cover tw-transition-opacity tw-duration-300 hover:tw-opacity-80">
                                     </a>
+                                    <span class="tw-mt-4 tw-inline-block tw-text-sm tw-text-gray-600">
+                                        {{ Str::ucfirst($c->type ?? 'kolekcia') }}
+                                    </span>
                                     <h4
-                                        class="tw-mt-4 tw-truncate tw-text-lg tw-font-semibold tw-text-black">
-                                        <a href="{{ route('frontend.article.detail', $a->slug) }}">
+                                        class="tw-truncate tw-text-lg tw-font-semibold tw-leading-tight tw-text-black">
+                                        <a href="{{ route('frontend.article.detail', $a->slug) }}"
+                                            title="{{ $a->title }}">
                                             {{ $a->title }}
                                         </a>
                                     </h4>
                                     <div class="tw-mt-2 tw-truncate tw-text-sm tw-text-gray-600">
-                                        {{ $a->published_date->format('d. m. Y') }} ∙
-                                        {{ $a->author }}
+                                        <a
+                                            href="{{ route('frontend.article.index', ['author' => $a->author]) }}">{{ $a->author }}</a>
+                                        ∙ {{ $a->published_date->format('d. m. Y') }}
                                     </div>
-                                    <span
-                                        class="tw-mt-2 tw-inline-block tw-bg-gray-200 tw-px-3 tw-py-1 tw-text-sm">
-                                        {{ Str::ucfirst($a->category->name ?? 'článok') }}
-                                    </span>
                                 </div>
                             @endforeach
                             <div
-                                class="tw-flex tw-h-full tw-w-full tw-flex-col tw-justify-center tw-bg-gray-200 tw-text-center tw-text-xl tw-font-semibold tw-text-black md:tw-w-1/3 xl:tw-w-1/4">
+                                class="tw-flex tw-h-48 tw-w-72 tw-flex-col tw-justify-center tw-bg-gray-200 tw-text-center tw-text-xl tw-font-semibold tw-text-black md:tw-w-[25rem]">
                                 <p>Na Webe umenia je ďalších viac<br /> ako
                                     {{ $articlesRemainingCount }} článkov</p>
-                                <a class="tw-mt-5 tw-underline tw-decoration-gray-300 tw-decoration-3 tw-underline-offset-4 hover:tw-decoration-current hover:tw-transition-colors"
+                                <a class="tw-mt-5 tw-underline tw-decoration-gray-300 tw-decoration-[3px] tw-underline-offset-4 hover:tw-decoration-current hover:tw-transition-colors"
                                     href="{{ route('frontend.article.index') }}">Zobraziť ďalšie
                                     články</a>
                             </div>
@@ -216,31 +219,32 @@
                 </div>
             </tabs-controller>
         </div>
-        <div class="tw-mb-6 tw-bg-gray-200 tw-py-6 lg:tw-py-16">
+        <div class="tw-bg-gray-200">
             <div
-                class="tw-container tw-mx-auto tw-max-w-screen-xl tw-gap-x-6 tw-px-6 lg:tw-grid lg:tw-grid-cols-2">
+                class="tw-container tw-mx-auto tw-max-w-screen-xl tw-gap-x-6 tw-px-6 tw-py-8 md:tw-py-16 lg:tw-grid lg:tw-grid-cols-2">
                 <div class="flex">
                     <img src="{{ $featuredAuthor->getImagePath() }}"
-                        class="tw-mt-14 tw-mr-6 tw-hidden tw-h-52 tw-w-52 tw-rounded-full lg:tw-block"
+                        class="tw-mt-12 tw-mr-6 tw-hidden tw-h-52 tw-w-52 tw-rounded-full lg:tw-block"
                         alt="{{ $featuredAuthor->formated_name }}">
                     <div>
-                        <h2 class="tw-font-semibold lg:tw-text-2xl">Autor týždňa</h2>
-                        <h2 class="tw-mt-2 tw-text-3xl tw-font-semibold lg:tw-mt-6 lg:tw-text-4xl">
+                        <h2 class="tw-font-semibold lg:tw-text-lg">Autor týždňa</h2>
+                        <h3 class="tw-mt-4 tw-text-3xl tw-font-semibold lg:tw-text-4xl">
                             <a href="{{ route('frontend.author.detail', $featuredAuthor) }}"
-                                class="tw-cursor-pointer tw-underline tw-decoration-gray-300 tw-underline-offset-4 tw-transition-colors hover:tw-decoration-current">
+                                class="tw-underline tw-decoration-gray-300 tw-underline-offset-4 tw-transition-colors hover:tw-decoration-current">
                                 {{ $featuredAuthor->formated_name }}
                             </a>
-                        </h2>
-                        <div class="tw-mt-3 lg:tw-text-lg">
+                        </h3>
+                        <div class="tw-mt-3 lg:tw-text-lg lg:tw-leading-snug">
                             @foreach ($featuredAuthor->roles as $role)
                                 <a href="{{ route('frontend.author.index', ['role' => $role]) }}"
-                                    class="tw-cursor-pointer">{{ $role }}</a>{{ $loop->last ? '' : ', ' }}
+                                    class="tw-cursor-pointer hover:tw-underline">{{ $role }}</a>{{ $loop->last ? '' : ', ' }}
                             @endforeach
                         </div>
                         <div class="tw-mt-3 tw-text-gray-500 lg:tw-text-lg">
-                            {{ $featuredAuthor->birth_date }} {{ $featuredAuthor->birth_place }}
+                            {{ Str::replace('.', '. ', $featuredAuthor->birth_date) }}
+                            {{ $featuredAuthor->birth_place }}
                             @if ($featuredAuthor->death_year)
-                                &mdash; {{ $featuredAuthor->death_date }}
+                                &mdash; {{ Str::replace('.', '. ', $featuredAuthor->death_date) }}
                                 {{ $featuredAuthor->death_place }}
                             @endif
                         </div>
@@ -258,7 +262,8 @@
                     </div>
                 </div>
 
-                <x-home.carousel class="tw-mt-6 lg:tw-mt-14" images-loaded>
+                <x-home.carousel class="tw-mt-6 lg:tw-mt-12" images-loaded
+                    button-container-class="tw-h-56">
                     @foreach ($featuredAuthor->items as $item)
                         <a href="{{ route('dielo', ['id' => $item]) }}"
                             class="tw-ml-4 tw-w-max first:tw-ml-0">
@@ -276,5 +281,6 @@
                 </a>
             </div>
         </div>
+
     </div>
 @stop

--- a/resources/views/home/index.blade.php
+++ b/resources/views/home/index.blade.php
@@ -49,6 +49,24 @@
                 </div>
             </div>
         @endif
+
+        {{-- Counts blurb --}}
+        <div class="tw-bg-gray-200">
+            <div
+                class="tw-container tw-mx-auto tw-grid tw-max-w-screen-xl tw-px-6 tw-py-5 tw-text-gray-500 lg:tw-py-10">
+                <p class="tw-text-center lg:tw-text-2xl">
+                    {{ utrans('intro.definition_start') }}
+                    <a href="{{ route('frontend.catalog.index') }}"
+                        class="tw-font-bold tw-text-gray-800 hover:tw-underline">{{ formatNum($countsBlurb->itemsCount) }}</a>
+                    {{ trans('intro.definition_end') }}<br>
+                    {{ $countsBlurb->start }}
+                    <a href="{{ $countsBlurb->url }}"
+                        class="tw-font-bold tw-text-gray-800 hover:tw-underline">{{ formatNum($countsBlurb->count) }}</a>
+                    {{ $countsBlurb->end }}
+                </p>
+            </div>
+        </div>
+
         @if ($featuredArtwork)
             <div class="tw-bg-gray-800 tw-text-white">
                 <div

--- a/resources/views/home/index.blade.php
+++ b/resources/views/home/index.blade.php
@@ -268,7 +268,7 @@
                         </div>
                         <a href="{{ route('frontend.author.detail', $featuredAuthor) }}"
                             class="tw-mt-6 tw-inline-block tw-border tw-border-gray-300 tw-px-4 tw-py-2 tw-text-sm tw-transition tw-duration-300 hover:tw-border-gray-400 hover:tw-bg-white hover:tw-text-gray-800">
-                            Zobraziť <strong>{{ $featuredAuthor->items->count() }} diel</strong> od
+                            Zobraziť <strong>{{ $featuredAuthor->items_count }} diel</strong> od
                             autora
                             <i class="fa icon-arrow-right tw-ml-2"></i>
                         </a>
@@ -282,7 +282,7 @@
 
                 <x-home.carousel class="tw-mt-6 lg:tw-mt-12" images-loaded
                     button-container-class="tw-h-56">
-                    @foreach ($featuredAuthor->items as $item)
+                    @foreach ($featuredAuthorItems as $item)
                         <a href="{{ route('dielo', ['id' => $item]) }}"
                             class="tw-ml-4 tw-w-max first:tw-ml-0">
                             <x-item_image :id="$item->id"

--- a/routes/api.php
+++ b/routes/api.php
@@ -19,6 +19,8 @@ Route::resource('/shared-user-collections', SharedUserCollectionController::clas
     ->names('api.shared-user-collections')
     ->parameters(['shared-user-collections' => 'collection:public_id']);
 
-Route::get('items', [ItemController::class, 'index']);
-Route::get('items/aggregations', [ItemController::class, 'aggregations']);
-Route::get('items/{id}', [ItemController::class, 'detail']);
+Route::prefix('v1')->group(function () {
+    Route::get('items', [ItemController::class, 'index']);
+    Route::get('items/aggregations', [ItemController::class, 'aggregations']);
+    Route::get('items/{id}', [ItemController::class, 'detail']);
+});

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -17,11 +17,15 @@ module.exports = {
                 },
             },
             fontFamily: {
-              "sans": ["GTWalsheim", "sans-serif"],
-              "serif": ["Source Serif Pro", "Minion", "Georgia", "Times New Roman", "Times", "serif"],
-            },
-            textDecorationThickness: {
-                3: '3px',
+                sans: ['GTWalsheim', 'sans-serif'],
+                serif: [
+                    'Source Serif Pro',
+                    'Minion',
+                    'Georgia',
+                    'Times New Roman',
+                    'Times',
+                    'serif',
+                ],
             },
         },
     },
@@ -30,4 +34,4 @@ module.exports = {
     corePlugins: {
         preflight: false, // TODO Not needed. Re-enable after switching from Bootstrap
     },
-};
+}


### PR DESCRIPTION
### Added
- global word-break:keep-all
- "counts blurb" to new homepage
- performance tweaks to new homepage

### Changed
- resolve api route name conflicts
 
### Fixed
- some styling issues with new Openseadragon
- disabled global Bootstrap `<a>` styles 