### PR TITLE
Item view count is indexed every 24 hours instead of immediately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file[^1].
 ## [Unreleased]
 ### Changed
 - KolekciaController to optimize queries
+- Item view count is indexed every 24 hours instead of immediately
 
 ## [2.60.0] - 2022-07-22
 ### Changed

--- a/app/Item.php
+++ b/app/Item.php
@@ -764,15 +764,6 @@ class Item extends Model implements IndexableModel, TranslatableContract
         ];
     }
 
-    public function incrementViewCount($save = true)
-    {
-        $this->timestamps = false;
-        $this->view_count++;
-        if ($save) {
-            $this->save();
-        }
-    }
-
     public function getUseTranslationFallback()
     {
         return $this->useTranslationFallback;

--- a/app/Item.php
+++ b/app/Item.php
@@ -529,7 +529,7 @@ class Item extends Model implements IndexableModel, TranslatableContract
             return $str;
         }
 
-        $array = explode($delimiter, $str);
+        $array = explode($delimiter, $str ?? '');
         $array = array_map(function ($value) {
             return trim($value);
         }, $array);

--- a/app/Jobs/ReindexItemsViewedSince.php
+++ b/app/Jobs/ReindexItemsViewedSince.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Elasticsearch\Repositories\ItemRepository;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Support\Carbon;
+
+class ReindexItemsViewedSince implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable;
+
+    private Carbon $since;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct(Carbon $since)
+    {
+        $this->since = $since;
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        app(ItemRepository::class)->reindexAllViewedSince($this->since);
+    }
+}

--- a/database/migrations/2022_07_22_132912_add_last_viewed_at_to_items.php
+++ b/database/migrations/2022_07_22_132912_add_last_viewed_at_to_items.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('items', function (Blueprint $table) {
+            $table
+                ->timestamp('last_viewed_at')
+                ->after('view_count')
+                ->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('items', function (Blueprint $table) {
+            $table->dropColumn('last_viewed_at');
+        });
+    }
+};

--- a/routes/web.php
+++ b/routes/web.php
@@ -45,6 +45,7 @@ use App\Item;
 use App\Notice;
 use App\Order;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\Redirect;
 use Illuminate\Support\Facades\Request;
 use Illuminate\Support\Facades\Route;
@@ -226,9 +227,12 @@ function()
         if (empty($item)) {
             abort(404);
         }
+
         $item->timestamps = false;
-        $item->view_count += 1;
-        $item->save();
+        $item->view_count++;
+        $item->last_viewed_at = Date::now();
+        $item->saveQuietly(); // Do not sync to search
+
         $previous = $next = false;
 
         $similar_items = $itemRepository->getSimilar(12, $item)->getCollection();


### PR DESCRIPTION
Adds a new `last_viewed_at` column which serves as an indicator for the daily `ReindexItemsViewedSince` job

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have updated the [CHANGELOG](../CHANGELOG.md)
- [x] I have requested at least 1 reviewer for this PR
- [ ] I have made corresponding changes to the documentation
