### PR TITLE
Set choice_translation_domain=false for item form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file[^1].
 ### Changed
 - KolekciaController to optimize queries
 
+### Fixed
+- Item admin form to not show 'item.' prefix in choices
+
 ## [2.60.0] - 2022-07-22
 ### Changed
 - Laravel version to 9

--- a/app/Forms/Types/ItemType.php
+++ b/app/Forms/Types/ItemType.php
@@ -28,12 +28,14 @@ class ItemType extends AbstractType
             ])
             ->add('description_user_id', ChoiceType::class, [
                 'choices' => User::pluck('id', 'username'),
+                'choice_translation_domain' => false
             ])
             ->add('identifier')
             ->add('author')
 
             ->add('tags', ChoiceType::class, [
                 'choices' => Item::existingTags()->pluck('name', 'name')->toArray(),
+                'choice_translation_domain' => false,
                 'multiple' => true,
                 'mapped' => false,
                 'required' => false,


### PR DESCRIPTION
in order to hide 'item.' prefixes in choice fields

![image](https://user-images.githubusercontent.com/1374745/181697986-3d7436ea-ada5-4bcb-a5db-e32321d67a1f.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have updated the [CHANGELOG](../CHANGELOG.md)
- [x] I have requested at least 1 reviewer for this PR
- [ ] I have made corresponding changes to the documentation
