### PR TITLE
filter items by collection_id in admin

### DIFF
--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -45,7 +45,15 @@ class ItemController extends Controller
      */
     public function index()
     {
-        $items = Item::orderBy('updated_at', 'DESC')->paginate(100);
+        $items = Item::orderBy('updated_at', 'DESC');
+
+        if (Request::has('collection_id')) {
+            $items->whereHas('collections', function ($query) {
+                $query->where('collections.id', Request::get('collection_id'));
+            });
+        }
+
+        $items = $items->paginate(100);
         // $collections = Collection::orderBy('order', 'ASC')->get();
         $collections = Collection::listsTranslations('name')->pluck('name', 'id')->toArray();
         $tags = Item::existingTags()->pluck('name','name');


### PR DESCRIPTION
# Description

Simple way to filter items in admin by collection by adding `?collection_id=XY` to url

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] I have updated the [CHANGELOG](../CHANGELOG.md)
- [x] I have requested at least 1 reviewer for this PR
- [ ] I have made corresponding changes to the documentation
