### PR TITLE
Webumenia 1527 add artwork quote to license modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file[^1].
 ### Fixed
 - lazy loading items for reindex
 
+### Added 
+- artwork info to citation note on download
+
 ## [2.66.0] - 2022-09-22
 ### Fixed
 - item detail view to eliminate N+1 queries

--- a/app/Item.php
+++ b/app/Item.php
@@ -172,7 +172,7 @@ class Item extends Model implements IndexableModel, TranslatableContract
 
     public function getCitation()
     {
-        return $this->author . ' - ' . $this->title . ', ' . $this->getDatingFormated() . ', ' . $this->gallery . ', ' . $this->getUrl();
+        return $this->getTitleWithAuthors() . ', ' . $this->getDatingFormated() . ', ' . $this->gallery . ', ' . $this->getUrl();
     }
 
     public static function loadValidatorMetadata(ClassMetadata $metadata) {

--- a/app/Item.php
+++ b/app/Item.php
@@ -170,6 +170,11 @@ class Item extends Model implements IndexableModel, TranslatableContract
 
     protected $useTranslationFallback;
 
+    public function getCitation()
+    {
+        return $this->author . ' - ' . $this->title . ', ' . $this->getDatingFormated() . ', ' . $this->gallery . ', ' . $this->getUrl();
+    }
+
     public static function loadValidatorMetadata(ClassMetadata $metadata) {
         $metadata->addGetterConstraint('images', new Valid());
     }

--- a/lang/cs/dielo.php
+++ b/lang/cs/dielo.php
@@ -40,11 +40,10 @@ return array(
     'more-items_related-artworks_by-data' => 'podle názvu, autora / autorky, tagů...',
     'more-items_similar-colors' => 'díla s podobnými barvami',
 
-    'modal_license_body-content'        => '<p><strong>Vámi zvolené dílo by se mělo v krátkém čase začít automaticky stahovat.</strong></p>
+    'modal_license_body-header'            => '<p><strong>Vámi zvolené dílo by se mělo v krátkém čase začít automaticky stahovat.</strong></p>
                                             <p>Digitální reprodukce volných děl na této stránce jsou přístupné jako <a href="https://creativecommons.org/publicdomain/mark/1.0/" target="_blank" class="underline">verejné vlastníctvo (public domain)</a>. Můžete si je volně stáhnout ve vysokém rozlišení a využívat k soukromým i komerčním účelům &ndash; kopírovat, sdílet i upravovat.</p>
-                                            <p>Při dalším šíření prosíme uvést:</p>
-                                            <pre><code>:author - :title, :date, :owner, :item_url</code></pre>
-                                            <p>Pokud plánujete využít reprodukce ke komerčním účelům, prosíme informujte o Vašich plánech dopředu, naši odborníci Vám mohou poradit. </p>
+                                            <p>Při dalším šíření prosíme uvést:</p>',
+    'modal_license_body-footer'         =>  '<p>Pokud plánujete využít reprodukce ke komerčním účelům, prosíme informujte o Vašich plánech dopředu, naši odborníci Vám mohou poradit. </p>
                                             <p><a class="underline" href=":free_url">Všechna díla volná ke stažení najdete zde.</a></p>',
     'modal_downloadfail_header-content' => 'Nastala chyba',
     'modal_downloadfail_body-content'   => '<p>Vámi zvolené dílo nebylo nyní možné stáhnout. Zkuste to prosím později.</p>  =

--- a/lang/cs/dielo.php
+++ b/lang/cs/dielo.php
@@ -42,7 +42,8 @@ return array(
 
     'modal_license_body-content'        => '<p><strong>Vámi zvolené dílo by se mělo v krátkém čase začít automaticky stahovat.</strong></p>
                                             <p>Digitální reprodukce volných děl na této stránce jsou přístupné jako <a href="https://creativecommons.org/publicdomain/mark/1.0/" target="_blank" class="underline">verejné vlastníctvo (public domain)</a>. Můžete si je volně stáhnout ve vysokém rozlišení a využívat k soukromým i komerčním účelům &ndash; kopírovat, sdílet i upravovat.</p>
-                                            <p>Při dalším šíření prosíme uvést: :author - :name, :date, :owner.<br><code>:item_url</code></p>
+                                            <p>Při dalším šíření prosíme uvést:</p>
+                                            <pre><code>:author - :title, :date, :owner, :item_url</code></pre>
                                             <p>Pokud plánujete využít reprodukce ke komerčním účelům, prosíme informujte o Vašich plánech dopředu, naši odborníci Vám mohou poradit. </p>
                                             <p><a class="underline" href=":free_url">Všechna díla volná ke stažení najdete zde.</a></p>',
     'modal_downloadfail_header-content' => 'Nastala chyba',

--- a/lang/cs/dielo.php
+++ b/lang/cs/dielo.php
@@ -42,7 +42,7 @@ return array(
 
     'modal_license_body-content'        => '<p><strong>Vámi zvolené dílo by se mělo v krátkém čase začít automaticky stahovat.</strong></p>
                                             <p>Digitální reprodukce volných děl na této stránce jsou přístupné jako <a href="https://creativecommons.org/publicdomain/mark/1.0/" target="_blank" class="underline">verejné vlastníctvo (public domain)</a>. Můžete si je volně stáhnout ve vysokém rozlišení a využívat k soukromým i komerčním účelům &ndash; kopírovat, sdílet i upravovat.</p>
-                                            <p>Při dalším šíření prosíme uvést jméno autora, název, majitele díla a zdroj <code>:item_url</code></p>
+                                            <p>Při dalším šíření prosíme uvést: :author - :name, :date, :owner.<br><code>:item_url</code></p>
                                             <p>Pokud plánujete využít reprodukce ke komerčním účelům, prosíme informujte o Vašich plánech dopředu, naši odborníci Vám mohou poradit. </p>
                                             <p><a class="underline" href=":free_url">Všechna díla volná ke stažení najdete zde.</a></p>',
     'modal_downloadfail_header-content' => 'Nastala chyba',

--- a/lang/en/dielo.php
+++ b/lang/en/dielo.php
@@ -40,11 +40,10 @@ return array(
     'more-items_related-artworks_by-data' => 'by title, artist, tags...',
     'more-items_similar-colors' => 'artworks with similar colours',
 
-    'modal_license_body-content'        => '<p><strong>Your selected artwork should start downloading automatically.</strong></p>
+    'modal_license_body-header'        => '<p><strong>Your selected artwork should start downloading automatically.</strong></p>
                                             <p>Downloadable digital reproductions of artworks on Web umenia are available as <a href="https://creativecommons.org/publicdomain/mark/1.0/" target="_blank" class="underline">public domain</a>. You can download them in high resolution and use them for both private and commercial use &ndash; i.e. copy, modify and share freely.</p>
-                                            <p>When sharing, please include:</p>
-                                            <pre><code>:author - :title, :date, :owner, :item_url</code></pre>
-                                            <p>If you intend to use the reproduction for commercial purpose, please inform us in advance, our experts can offer advice.</p>
+                                            <p>When sharing, please include:</p>',
+    'modal_license_body-footer'         => '<p>If you intend to use the reproduction for commercial purpose, please inform us in advance, our experts can offer advice.</p>
                                             <p><a class="underline" href=":free_url">You can find all downloadable artworks here.</a></p>',
     'modal_downloadfail_header-content' => 'An error has occured',
     'modal_downloadfail_body-content'   => '<p>Your selected artwork could not be downloaded at this time. Please try again later.</p>

--- a/lang/en/dielo.php
+++ b/lang/en/dielo.php
@@ -42,7 +42,8 @@ return array(
 
     'modal_license_body-content'        => '<p><strong>Your selected artwork should start downloading automatically.</strong></p>
                                             <p>Downloadable digital reproductions of artworks on Web umenia are available as <a href="https://creativecommons.org/publicdomain/mark/1.0/" target="_blank" class="underline">public domain</a>. You can download them in high resolution and use them for both private and commercial use &ndash; i.e. copy, modify and share freely.</p>
-                                            <p>When sharing, please include: :author - :name, :date, :owner.<br><code>:item_url</code></p>
+                                            <p>When sharing, please include:</p>
+                                            <pre><code>:author - :title, :date, :owner, :item_url</code></pre>
                                             <p>If you intend to use the reproduction for commercial purpose, please inform us in advance, our experts can offer advice.</p>
                                             <p><a class="underline" href=":free_url">You can find all downloadable artworks here.</a></p>',
     'modal_downloadfail_header-content' => 'An error has occured',

--- a/lang/en/dielo.php
+++ b/lang/en/dielo.php
@@ -42,7 +42,7 @@ return array(
 
     'modal_license_body-content'        => '<p><strong>Your selected artwork should start downloading automatically.</strong></p>
                                             <p>Downloadable digital reproductions of artworks on Web umenia are available as <a href="https://creativecommons.org/publicdomain/mark/1.0/" target="_blank" class="underline">public domain</a>. You can download them in high resolution and use them for both private and commercial use &ndash; i.e. copy, modify and share freely.</p>
-                                            <p>When sharing, please include the artist name, artwork title, owner and the source <code>:item_url</code></p>
+                                            <p>When sharing, please include: :author - :name, :date, :owner.<br><code>:item_url</code></p>
                                             <p>If you intend to use the reproduction for commercial purpose, please inform us in advance, our experts can offer advice.</p>
                                             <p><a class="underline" href=":free_url">You can find all downloadable artworks here.</a></p>',
     'modal_downloadfail_header-content' => 'An error has occured',

--- a/lang/sk/dielo.php
+++ b/lang/sk/dielo.php
@@ -44,7 +44,8 @@ return array(
 
     'modal_license_body-content'        => '<p><strong>Vami zvolené dielo by sa malo začať v krátkom čase automaticky sťahovať.</strong></p>
                                             <p>Digitálne reprodukcie voľných diel na tejto stránke sú sprístupnené ako <a href="https://creativecommons.org/publicdomain/mark/1.0/" target="_blank" class="underline">verejné vlastníctvo (public domain)</a>. Môžete si ich voľne stiahnuť vo vysokom rozlíšení a využívať na súkromné aj komerčné účely &ndash; kopírovať, zdieľať i upravovať.</p>
-                                            <p>Pri ďalšom šírení prosíme uviesť: :author - :name, :date, :owner.<br><code>:item_url</code></p>
+                                            <p>Pri ďalšom šírení prosíme uviesť:</p>
+                                            <pre><code>:author - :title, :date, :owner, :item_url</code></pre>
                                             <p>Ak plánujete využiť reprodukcie na komerčné účely, prosím informujte nás o vašich plánoch vopred, naši odborníci vám vedia poradiť.</p>
                                             <p><a class="underline" href=":free_url">Všetky voľne stiahnuteľné diela nájdete tu.</a></p>',
     'modal_downloadfail_header-content' => 'Nastala chyba',

--- a/lang/sk/dielo.php
+++ b/lang/sk/dielo.php
@@ -42,11 +42,10 @@ return array(
     'more-items_related-artworks_by-data' => 'podľa názvu, autora / autorky, tagov...',
     'more-items_similar-colors' => 'diela s podobnými farbami',
 
-    'modal_license_body-content'        => '<p><strong>Vami zvolené dielo by sa malo začať v krátkom čase automaticky sťahovať.</strong></p>
+    'modal_license_body-header' =>          '<p><strong>Vami zvolené dielo by sa malo začať v krátkom čase automaticky sťahovať.</strong></p>
                                             <p>Digitálne reprodukcie voľných diel na tejto stránke sú sprístupnené ako <a href="https://creativecommons.org/publicdomain/mark/1.0/" target="_blank" class="underline">verejné vlastníctvo (public domain)</a>. Môžete si ich voľne stiahnuť vo vysokom rozlíšení a využívať na súkromné aj komerčné účely &ndash; kopírovať, zdieľať i upravovať.</p>
-                                            <p>Pri ďalšom šírení prosíme uviesť:</p>
-                                            <pre><code>:author - :title, :date, :owner, :item_url</code></pre>
-                                            <p>Ak plánujete využiť reprodukcie na komerčné účely, prosím informujte nás o vašich plánoch vopred, naši odborníci vám vedia poradiť.</p>
+                                            <p>Pri ďalšom šírení prosíme uviesť:</p>',
+    'modal_license_body-footer'         => '<p>Ak plánujete využiť reprodukcie na komerčné účely, prosím informujte nás o vašich plánoch vopred, naši odborníci vám vedia poradiť.</p>
                                             <p><a class="underline" href=":free_url">Všetky voľne stiahnuteľné diela nájdete tu.</a></p>',
     'modal_downloadfail_header-content' => 'Nastala chyba',
     'modal_downloadfail_body-content'   => '<p>Vami zvolené dielo nebolo možné v tomto momente stiahnuť. Skúste to prosím neskôr.</p>

--- a/lang/sk/dielo.php
+++ b/lang/sk/dielo.php
@@ -44,7 +44,7 @@ return array(
 
     'modal_license_body-content'        => '<p><strong>Vami zvolené dielo by sa malo začať v krátkom čase automaticky sťahovať.</strong></p>
                                             <p>Digitálne reprodukcie voľných diel na tejto stránke sú sprístupnené ako <a href="https://creativecommons.org/publicdomain/mark/1.0/" target="_blank" class="underline">verejné vlastníctvo (public domain)</a>. Môžete si ich voľne stiahnuť vo vysokom rozlíšení a využívať na súkromné aj komerčné účely &ndash; kopírovať, zdieľať i upravovať.</p>
-                                            <p>Pri ďalšom šírení prosíme uviesť meno autora, názov, majiteľa diela a zdroj <code>:item_url</code></p>
+                                            <p>Pri ďalšom šírení prosíme uviesť: :author - :name, :date, :owner.<br><code>:item_url</code></p>
                                             <p>Ak plánujete využiť reprodukcie na komerčné účely, prosím informujte nás o vašich plánoch vopred, naši odborníci vám vedia poradiť.</p>
                                             <p><a class="underline" href=":free_url">Všetky voľne stiahnuteľné diela nájdete tu.</a></p>',
     'modal_downloadfail_header-content' => 'Nastala chyba',

--- a/public/js/components/share_buttons.js
+++ b/public/js/components/share_buttons.js
@@ -1,10 +1,8 @@
-function copyToClipboard(url, message, el) {
-    var $temp = $("<input>");
-    $("#shareLink").append($temp);
-    $temp.val(url).select();
-    var successful = document.execCommand("copy");
-    $temp.remove();
-    var msg = successful ? message : 'Whoops, not copied...';
+async function copyToClipboard(url, message, el) {
+    var msg = 'Whoops, not copied...';
+    await navigator.clipboard.writeText(url).then(() => {
+      msg = message;
+    });
     el.attr('data-original-title', msg).tooltip('show');
     setTimeout(function () {
       el.tooltip('hide');

--- a/resources/views/components/copy_button.blade.php
+++ b/resources/views/components/copy_button.blade.php
@@ -1,4 +1,6 @@
-<a href="#" class="js-copy" data-message="{{ trans('general.copied_to_clipboard') }}"
-    data-url="{{ $text }}" data-toggle="tooltip" data-trigger="manual" data-container="body"
-    title="{{ trans('general.copy') }}"><i class="fa fa-clipboard" aria-hidden="true"></i>
-    {!! trans('general.copy') !!}</a>
+<div class="pb-2">
+    <a href="#" class="js-copy" data-message="{{ trans('general.copied_to_clipboard') }}"
+        data-url="{{ $text }}" data-toggle="tooltip" data-trigger="manual" data-container="body"
+        title="{{ trans('general.copy') }}"><i class="fa fa-clipboard" aria-hidden="true"></i>
+        {!! trans('general.copy') !!}</a>
+</div>

--- a/resources/views/components/copy_button.blade.php
+++ b/resources/views/components/copy_button.blade.php
@@ -1,0 +1,4 @@
+<a href="#" class="js-copy" data-message="{{ trans('general.copied_to_clipboard') }}"
+    data-url="{{ $text }}" data-toggle="tooltip" data-trigger="manual" data-container="body"
+    title="{{ trans('general.copy') }}"><i class="fa fa-clipboard" aria-hidden="true"></i>
+    {!! trans('general.copy') !!}</a>

--- a/resources/views/components/share_buttons.blade.php
+++ b/resources/views/components/share_buttons.blade.php
@@ -48,15 +48,9 @@
             </div>
             <div class="modal-body text-left">
                 <code>{{ $url }}</code>
-                <a href="#"
-                   class="pull-right js-copy"
-                   data-message="{{ trans('general.copied_to_clipboard') }}"
-                   data-url="{{ $url }}"
-                   data-toggle="tooltip"
-                   data-trigger="manual"
-                   data-container="body"
-                   title="{{ trans('general.copy') }}"
-                ><i class="fa fa-clipboard" aria-hidden="true"></i> {{ trans('general.copy') }}</a>
+                <div class="pull-right">
+                @include('components.copy_button', ['text' => $url])
+                </div>
             </div>
             <div class="modal-footer">
                 <div class="text-center"><button type="button" data-dismiss="modal"

--- a/resources/views/dielo.blade.php
+++ b/resources/views/dielo.blade.php
@@ -40,10 +40,6 @@
 </section>
 @endif
 
-@php
-    $citation = $item->author . ' - ' . $item->title . ', ' . $item->getDatingFormated() . ', ' . $item->gallery . ', ' . $item->getUrl();
-@endphp
-
 <section class="item top-section" itemscope itemtype="http://schema.org/VisualArtwork">
     <div class="item-body">
         <div class="container">
@@ -479,9 +475,9 @@
             <div class="modal-body">
                 {!! trans('dielo.modal_license_body-header') !!}
                 <div>
-                    <pre><code>{{ $citation }}</code></pre>
+                    <pre><code>{{ $item->getCitation() }}</code></pre>
                 </div>
-                @include('components.copy_button', ['text' => $citation])
+                @include('components.copy_button', ['text' => $item->getCitation()])
                 {!! trans('dielo.modal_license_body-footer', ['free_url' => URL::to('katalog?is_free=1')]) !!}
             </div>
             <div class="modal-footer">

--- a/resources/views/dielo.blade.php
+++ b/resources/views/dielo.blade.php
@@ -473,8 +473,14 @@
                 <img src="{{ URL::asset('images/license/cc.svg') }}" alt="Creative Commons">
             </div>
             <div class="modal-body">
-                {!! trans('dielo.modal_license_body-content', ['item_url' => $item->getUrl(), 'free_url' =>
-                URL::to('katalog?is_free=1')] ) !!}
+                {!! trans('dielo.modal_license_body-content', [
+                'item_url' => $item->getUrl(), 
+                'free_url' => URL::to('katalog?is_free=1'),
+                'author' => $item->author,
+                'name' => $item->title,
+                'date' => $item->getDatingFormated(),
+                'owner' => $item->gallery,
+                ] ) !!}
             </div>
             <div class="modal-footer">
                 <div class="text-center"><button type="button" data-dismiss="modal"

--- a/resources/views/dielo.blade.php
+++ b/resources/views/dielo.blade.php
@@ -40,6 +40,10 @@
 </section>
 @endif
 
+@php
+    $citation = $item->author . ' - ' . $item->title . ', ' . $item->getDatingFormated() . ', ' . $item->gallery . ', ' . $item->getUrl();
+@endphp
+
 <section class="item top-section" itemscope itemtype="http://schema.org/VisualArtwork">
     <div class="item-body">
         <div class="container">
@@ -473,14 +477,12 @@
                 <img src="{{ URL::asset('images/license/cc.svg') }}" alt="Creative Commons">
             </div>
             <div class="modal-body">
-                {!! trans('dielo.modal_license_body-content', [
-                'item_url' => $item->getUrl(), 
-                'free_url' => URL::to('katalog?is_free=1'),
-                'author' => $item->author,
-                'title' => $item->title,
-                'date' => $item->getDatingFormated(),
-                'owner' => $item->gallery,
-                ] ) !!}
+                {!! trans('dielo.modal_license_body-header') !!}
+                <div>
+                    <pre><code>{{ $citation }}</code></pre>
+                </div>
+                @include('components.copy_button', ['text' => $citation])
+                {!! trans('dielo.modal_license_body-footer', ['free_url' => URL::to('katalog?is_free=1')]) !!}
             </div>
             <div class="modal-footer">
                 <div class="text-center"><button type="button" data-dismiss="modal"

--- a/resources/views/dielo.blade.php
+++ b/resources/views/dielo.blade.php
@@ -477,7 +477,7 @@
                 'item_url' => $item->getUrl(), 
                 'free_url' => URL::to('katalog?is_free=1'),
                 'author' => $item->author,
-                'name' => $item->title,
+                'title' => $item->title,
                 'date' => $item->getDatingFormated(),
                 'owner' => $item->gallery,
                 ] ) !!}


### PR DESCRIPTION
# Description
Add artwork citation (same format as "copy citation") to license modal (displayed after clicking "download artwork")
![Snímka obrazovky 2022-08-31 o 10 16 11](https://user-images.githubusercontent.com/28804184/187629117-8fcc7dc9-a62c-4499-8ed4-3094ce4b26a8.png)

Fixes [https://jira.sng.sk/browse/WEBUMENIA-1527)]

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have updated the [CHANGELOG](../CHANGELOG.md)
- [x] I have requested at least 1 reviewer for this PR
- [ ] I have made corresponding changes to the documentation
