### PR TITLE
[item] fix lazy loading for reindex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file[^1].
 
 ## [Unreleased]
+### Fixed
+- lazy loading items for reindex
 
 ## [2.66.0] - 2022-09-22
 ### Fixed

--- a/app/Elasticsearch/Repositories/ItemRepository.php
+++ b/app/Elasticsearch/Repositories/ItemRepository.php
@@ -466,6 +466,7 @@ class ItemRepository extends TranslatableRepository
 
                 return $operations;
             })
+            // chunk size = 2 operations * number of locales * 200 items
             ->chunk(2 * count($this->locales) * 200)
             ->each(function ($operations) use (&$processedCount) {
                 $this->elasticsearch->bulk(['body' => $operations]);


### PR DESCRIPTION
Removed cross join since it was fetching all items at once