### PR TITLE
Webumenia 1916 include date earliest latest in items api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file[^1].
 
 ## [Unreleased]
+### Added
+- date_earliest and date_latest in ItemResource
+
+### Fixed
+- mapping of item dating in harvester
 
 ## [2.70.0] - 2022-11-08
 ### Added

--- a/app/Harvest/Mappers/ItemMapper.php
+++ b/app/Harvest/Mappers/ItemMapper.php
@@ -125,13 +125,8 @@ class ItemMapper extends AbstractMapper
             return str_contains($dating, ', ');
         });
 
-        $datings = array_map(function($dating) {
-            $dating = explode(', ', $dating);
-            return end($dating);
-        }, $datings);
-
         if ($datings) {
-            return implode(', ', $datings);
+            return implode("\n", $datings);
         } elseif (isset($row['created'][0])) {
             return $row['created'][0];
         }

--- a/app/Harvest/Mappers/ItemMapper.php
+++ b/app/Harvest/Mappers/ItemMapper.php
@@ -126,7 +126,7 @@ class ItemMapper extends AbstractMapper
         });
 
         if ($datings) {
-            return implode("\n", $datings);
+            return implode('; ', $datings);
         } elseif (isset($row['created'][0])) {
             return $row['created'][0];
         }

--- a/app/Http/Resources/Api/V2/ItemResource.php
+++ b/app/Http/Resources/Api/V2/ItemResource.php
@@ -19,6 +19,8 @@ class ItemResource extends JsonResource
             'title' => $this->title,
             'authors' => $this->getUniqueAuthorsWithAuthorityNames(),
             'dating' => $this->dating,
+            'date_earliest' => $this->date_earliest,
+            'date_latest' => $this->date_latest,
             'description' => $this->description,
             'authorities' => AuthorityResource::collection($this->authorities),
         ];

--- a/app/Http/Resources/Api/V2/ItemResource.php
+++ b/app/Http/Resources/Api/V2/ItemResource.php
@@ -18,7 +18,7 @@ class ItemResource extends JsonResource
             'id' => $this->id,
             'title' => $this->title,
             'authors' => $this->getUniqueAuthorsWithAuthorityNames(),
-            'dating' => $this->dating,
+            'dating' => $this->getDatingFormated(true),
             'date_earliest' => $this->date_earliest,
             'date_latest' => $this->date_latest,
             'description' => $this->description,

--- a/app/Item.php
+++ b/app/Item.php
@@ -489,7 +489,7 @@ class Item extends Model implements IndexableModel, TranslatableContract
         return $value;
     }
 
-    public function getDatingFormated($single_line = false)
+    public function getDatingFormated($single_line = true)
     {
         $count_digits = preg_match_all("/[0-9]/", $this->dating);
         if (($count_digits<2) && !empty($this->date_earliest)) {

--- a/app/Item.php
+++ b/app/Item.php
@@ -489,7 +489,7 @@ class Item extends Model implements IndexableModel, TranslatableContract
         return $value;
     }
 
-    public function getDatingFormated()
+    public function getDatingFormated($single_line = false)
     {
         $count_digits = preg_match_all("/[0-9]/", $this->dating);
         if (($count_digits<2) && !empty($this->date_earliest)) {
@@ -499,7 +499,13 @@ class Item extends Model implements IndexableModel, TranslatableContract
             }
             return $formated;
         }
-        $trans = array("/" => "–", "-" => "–");
+        $trans = [
+            "/" => "–", 
+            "-" => "–",
+        ];
+        if ($single_line) {
+           $trans["\n"] = "; ";
+        }
         $formated = preg_replace('/^([0-9]*) \s*([a-zA-Z]*)$/', '$2 $1', $this->dating);
         $parts = explode('/', $formated);
         $formated = implode('/', array_unique($parts));

--- a/app/Item.php
+++ b/app/Item.php
@@ -489,7 +489,7 @@ class Item extends Model implements IndexableModel, TranslatableContract
         return $value;
     }
 
-    public function getDatingFormated($single_line = true)
+    public function getDatingFormated($multi_line = false)
     {
         $count_digits = preg_match_all("/[0-9]/", $this->dating);
         if (($count_digits<2) && !empty($this->date_earliest)) {
@@ -503,8 +503,8 @@ class Item extends Model implements IndexableModel, TranslatableContract
             "/" => "–", 
             "-" => "–",
         ];
-        if ($single_line) {
-           $trans["\n"] = "; ";
+        if ($multi_line) {
+           $trans["; "] = "\n";
         }
         $formated = preg_replace('/^([0-9]*) \s*([a-zA-Z]*)$/', '$2 $1', $this->dating);
         $parts = explode('/', $formated);

--- a/resources/views/components/artwork_grid_item.blade.php
+++ b/resources/views/components/artwork_grid_item.blade.php
@@ -26,7 +26,7 @@
         <a href="{{ $url }}">
             @if( !isset($hide_authors) ) <em>{!! implode(', ', $item->authorsFormatted) !!}</em><br> @endif
             @if( !isset($hide_title) ) <strong>{!! $item->title !!}</strong><br> @endif
-            @if( !isset($hide_dating) ) <em>{!! nl2br($item->getDatingFormated($single_line = true)) !!}</em> @endif
+            @if( !isset($hide_dating) ) <em>{!! nl2br($item->getDatingFormated(true)) !!}</em> @endif
         </a>
     </div>
 </div>

--- a/resources/views/components/artwork_grid_item.blade.php
+++ b/resources/views/components/artwork_grid_item.blade.php
@@ -26,7 +26,7 @@
         <a href="{{ $url }}">
             @if( !isset($hide_authors) ) <em>{!! implode(', ', $item->authorsFormatted) !!}</em><br> @endif
             @if( !isset($hide_title) ) <strong>{!! $item->title !!}</strong><br> @endif
-            @if( !isset($hide_dating) ) <em>{!! $item->getDatingFormated() !!}</em> @endif
+            @if( !isset($hide_dating) ) <em>{!! nl2br($item->getDatingFormated()) !!}</em> @endif
         </a>
     </div>
 </div>

--- a/resources/views/components/artwork_grid_item.blade.php
+++ b/resources/views/components/artwork_grid_item.blade.php
@@ -26,7 +26,7 @@
         <a href="{{ $url }}">
             @if( !isset($hide_authors) ) <em>{!! implode(', ', $item->authorsFormatted) !!}</em><br> @endif
             @if( !isset($hide_title) ) <strong>{!! $item->title !!}</strong><br> @endif
-            @if( !isset($hide_dating) ) <em>{!! nl2br($item->getDatingFormated()) !!}</em> @endif
+            @if( !isset($hide_dating) ) <em>{!! nl2br($item->getDatingFormated($single_line = true)) !!}</em> @endif
         </a>
     </div>
 </div>

--- a/resources/views/dielo.blade.php
+++ b/resources/views/dielo.blade.php
@@ -120,7 +120,7 @@
                                 <td class="atribut">{{ trans('dielo.item_attr_dating') }}:</td>
                                 <td>
                                     <time itemprop="dateCreated" datetime="{{ $item->date_earliest }}">
-                                        {!!nl2br($item->getDatingFormated($single_line = false)) !!}
+                                        {!! nl2br($item->getDatingFormated(true)) !!}
                                     </time>
                                 </td>
                             </tr>

--- a/resources/views/dielo.blade.php
+++ b/resources/views/dielo.blade.php
@@ -120,7 +120,7 @@
                                 <td class="atribut">{{ trans('dielo.item_attr_dating') }}:</td>
                                 <td>
                                     <time itemprop="dateCreated" datetime="{{ $item->date_earliest }}">
-                                        {{ $item->getDatingFormated() }}
+                                        {!!nl2br($item->getDatingFormated()) !!}
                                     </time>
                                 </td>
                             </tr>

--- a/resources/views/dielo.blade.php
+++ b/resources/views/dielo.blade.php
@@ -120,7 +120,7 @@
                                 <td class="atribut">{{ trans('dielo.item_attr_dating') }}:</td>
                                 <td>
                                     <time itemprop="dateCreated" datetime="{{ $item->date_earliest }}">
-                                        {!!nl2br($item->getDatingFormated()) !!}
+                                        {!!nl2br($item->getDatingFormated($single_line = false)) !!}
                                     </time>
                                 </td>
                             </tr>

--- a/resources/views/objednavka.blade.php
+++ b/resources/views/objednavka.blade.php
@@ -67,7 +67,7 @@
                                     </a>
                                     <div class="media-body">
                                         <a href="{!! $item->getUrl() !!}">
-                                            <em>{!! implode(', ', $item->authors) !!}</em> <br> <strong>{!! $item->title !!}</strong> (<em>{!! $item->getDatingFormated() !!}</em>)
+                                            <em>{!! implode(', ', $item->authors) !!}</em> <br> <strong>{!! $item->title !!}</strong> (<em>{!! $item->getDatingFormated($single_line = true) !!}</em>)
                                         </a><br>
                                         <p class="item"><a href="{!! URL::to('dielo/' . $item->id . '/odstranit') !!}" class="underline"><i class="fa fa-times"></i> {{ trans('objednavka.order_remove') }}</a></span>
                                         @if ($item->images->isEmpty())

--- a/resources/views/objednavka.blade.php
+++ b/resources/views/objednavka.blade.php
@@ -67,7 +67,7 @@
                                     </a>
                                     <div class="media-body">
                                         <a href="{!! $item->getUrl() !!}">
-                                            <em>{!! implode(', ', $item->authors) !!}</em> <br> <strong>{!! $item->title !!}</strong> (<em>{!! $item->getDatingFormated() !!}</em>)
+                                            <em>{{ implode(', ', $item->authors) }}</em> <br> <strong>{{ $item->title }}</strong> (<em>{{ $item->getDatingFormated() }}</em>)
                                         </a><br>
                                         <p class="item"><a href="{!! URL::to('dielo/' . $item->id . '/odstranit') !!}" class="underline"><i class="fa fa-times"></i> {{ trans('objednavka.order_remove') }}</a></span>
                                         @if ($item->images->isEmpty())

--- a/resources/views/objednavka.blade.php
+++ b/resources/views/objednavka.blade.php
@@ -67,7 +67,7 @@
                                     </a>
                                     <div class="media-body">
                                         <a href="{!! $item->getUrl() !!}">
-                                            <em>{!! implode(', ', $item->authors) !!}</em> <br> <strong>{!! $item->title !!}</strong> (<em>{!! $item->getDatingFormated($single_line = true) !!}</em>)
+                                            <em>{!! implode(', ', $item->authors) !!}</em> <br> <strong>{!! $item->title !!}</strong> (<em>{!! $item->getDatingFormated() !!}</em>)
                                         </a><br>
                                         <p class="item"><a href="{!! URL::to('dielo/' . $item->id . '/odstranit') !!}" class="underline"><i class="fa fa-times"></i> {{ trans('objednavka.order_remove') }}</a></span>
                                         @if ($item->images->isEmpty())

--- a/tests/Harvest/Mappers/ItemMapperTest.php
+++ b/tests/Harvest/Mappers/ItemMapperTest.php
@@ -153,8 +153,7 @@ class ItemMapperTest extends TestCase
             'inscription:sk' => 'vpravo dole gravé J.Daullé..; vľavo dole peint Teniers',
             'place:sk' => null,
             'gallery:sk' => 'Slovenská národná galéria, SNG',
-            'dating:sk' => '18. storočie, polovica, 1760 (originál)
-21. storočie, 1. polovica, 2019 (zväčšenina)',
+            'dating:sk' => '18. storočie, polovica, 1760 (originál); 21. storočie, 1. polovica, 2019 (zväčšenina)',
             'relationship_type:sk' => 'samostatné dielo',
             'related_work:sk' => null,
             'work_level:sk' => null,

--- a/tests/Harvest/Mappers/ItemMapperTest.php
+++ b/tests/Harvest/Mappers/ItemMapperTest.php
@@ -153,7 +153,8 @@ class ItemMapperTest extends TestCase
             'inscription:sk' => 'vpravo dole gravé J.Daullé..; vľavo dole peint Teniers',
             'place:sk' => null,
             'gallery:sk' => 'Slovenská národná galéria, SNG',
-            'dating:sk' => '1760 (originál), 2019 (zväčšenina)',
+            'dating:sk' => '18. storočie, polovica, 1760 (originál)
+21. storočie, 1. polovica, 2019 (zväčšenina)',
             'relationship_type:sk' => 'samostatné dielo',
             'related_work:sk' => null,
             'work_level:sk' => null,


### PR DESCRIPTION
# Description

- include `date_earliest` and `date_latest` in ItemResource fro API v2
- fix mapping of item `dating` in harvester

Before:
<img width="832" alt="Snímka obrazovky 2022-11-28 o 14 36 45" src="https://user-images.githubusercontent.com/2682941/204291383-24edcdbb-b73c-4678-a43c-22b2af888527.png">


After:
<img width="816" alt="Snímka obrazovky 2022-11-28 o 14 29 51" src="https://user-images.githubusercontent.com/2682941/204291418-9016df08-e57f-4c4d-8bee-0f55e0b4477d.png">

Proposed change keeps whole `dating` as it came from OAI-PMH
If there is multiple values, break them in multiple lines.
E.g.:
```
'created' => [
                '1760/1760',
                '18. storočie, polovica, 1760 (originál)',
                '1860/1860',
                '21. storočie, 1. polovica, 2019 (zväčšenina)',
            ],
```
result
```
18. storočie, polovica, 1760 (originál)
21. storočie, 1. polovica, 2019 (zväčšenina)
```

Fixes [WEBUMENIA-1916](https://jira.sng.sk/browse/WEBUMENIA-1916)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] I have updated the [CHANGELOG](../CHANGELOG.md)
- [ ] I have requested at least 1 reviewer for this PR
- [ ] I have made corresponding changes to the documentation
