### PR TITLE
Add authors_formatted field to /api/v1/items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file[^1].
 
 ## [Unreleased]
+### Added
+- authors_formatted field to /api/v1/items
 
 ## [2.75.0] - 2023-05-11
 ### Changed

--- a/app/Http/Controllers/Api/V1/ItemController.php
+++ b/app/Http/Controllers/Api/V1/ItemController.php
@@ -14,7 +14,6 @@ use Primal\Color\Parser as ColorParser;
 
 class ItemController extends Controller
 {
-
     private $filterables = [
         'author',
         'topic',
@@ -32,11 +31,7 @@ class ItemController extends Controller
         'additionals.location.keyword',
     ];
 
-    private $rangeables = [
-        'date_earliest',
-        'date_latest',
-        'additionals.order',
-    ];
+    private $rangeables = ['date_earliest', 'date_latest', 'additionals.order'];
 
     private $sortables = [
         'date_earliest',
@@ -75,7 +70,25 @@ class ItemController extends Controller
                 $searchRequest->sort($field, $direction);
             });
 
-        return $searchRequest->paginate($size)->onlyDocuments();
+        $response = $searchRequest
+            ->paginate($size)
+            ->onlyDocuments()
+            ->toArray();
+
+        return [
+            ...$response,
+            'data' => collect($response['data'])->map(
+                fn($document) => [
+                    ...$document,
+                    'content' => [
+                        ...$document['content'],
+                        'authors_formatted' => collect($document['content']['author'])->map(
+                            fn($author) => formatName($author)
+                        ),
+                    ],
+                ]
+            ),
+        ];
     }
 
     public function aggregations(Request $request)

--- a/tests/Feature/Api/V1/ItemsTest.php
+++ b/tests/Feature/Api/V1/ItemsTest.php
@@ -15,7 +15,9 @@ class ItemsTest extends TestCase
 
     public function test_no_filters_applied()
     {
-        Item::factory()->count(3)->create();
+        Item::factory()
+            ->count(3)
+            ->create();
         app(ItemRepository::class)->refreshIndex();
 
         $url = route('api.v1.items.index');
@@ -86,10 +88,7 @@ class ItemsTest extends TestCase
 
         $response = $this->getJson($url);
 
-        $this->assertNotContains(
-            $different->id,
-            collect($response['data'])->pluck('id')
-        );
+        $this->assertNotContains($different->id, collect($response['data'])->pluck('id'));
 
         $response->assertJson([
             'total' => 2,
@@ -118,7 +117,9 @@ class ItemsTest extends TestCase
 
     public function test_random_sort()
     {
-        Item::factory()->count(5)->create(['has_image' => true]); // Images are required for random sort
+        Item::factory()
+            ->count(5)
+            ->create(['has_image' => true]); // Images are required for random sort
         app(ItemRepository::class)->refreshIndex();
 
         $url = route('api.v1.items.index', [
@@ -131,7 +132,24 @@ class ItemsTest extends TestCase
 
         $this->assertNotSame(
             collect($response1['data'])->pluck('id'),
-            collect($response2['data'])->pluck('id'),
+            collect($response2['data'])->pluck('id')
+        );
+    }
+
+    public function test_formatted_authors()
+    {
+        Item::factory()->create(['author' => 'Věšín, Jaroslav']);
+        app(ItemRepository::class)->refreshIndex();
+
+        $url = route('api.v1.items.index', [
+            'size' => 1,
+        ]);
+
+        $response = $this->getJson($url);
+
+        $this->assertEquals(
+            'Jaroslav Věšín',
+            $response['data'][0]['content']['authors_formatted'][0]
         );
     }
 }


### PR DESCRIPTION
This extends the V1 API instead of creating a V2, as creating a V2 would be too big a commitment :)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have updated the [CHANGELOG](../CHANGELOG.md)
- [x] I have requested at least 1 reviewer for this PR
- [ ] I have made corresponding changes to the documentation
