### PR TITLE
Change /api/v1/items/aggregations filtering logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file[^1].
 ### Added
 - images:generate-ratios command
 
+### Changed
+- behaviour for /api/v1/items/aggregations so that facet doesn't filter itself
+
 ## [2.78.0] - 2023-07-21
 ### Added
 - images->deep_zoom_url to /api/v2/items/{id}

--- a/app/Http/Controllers/Api/V1/ItemController.php
+++ b/app/Http/Controllers/Api/V1/ItemController.php
@@ -124,9 +124,19 @@ class ItemController extends Controller
         // Add filter terms to each aggregation
         // Based on https://madewithlove.com/blog/faceted-search-using-elasticsearch/
         foreach (array_keys($aggregationsQuery) as $term) {
+            $termFilter = Arr::except($filter, $term);
+
+            // Additionally exclude date_latest for date_earliest and vice versa
+            if ($term === 'date_earliest') {
+                $termFilter = Arr::except($termFilter, 'date_latest');
+            }
+            if ($term === 'date_latest') {
+                $termFilter = Arr::except($termFilter, 'date_earliest');
+            }
+
             $aggregationsQuery[$term]['filter'] = $this->createQueryBuilder(
                 $q,
-                Arr::except($filter, $term)
+                $termFilter
             )->buildQuery();
         }
 

--- a/app/Http/Controllers/Api/V1/ItemController.php
+++ b/app/Http/Controllers/Api/V1/ItemController.php
@@ -126,7 +126,7 @@ class ItemController extends Controller
         foreach (array_keys($aggregationsQuery) as $term) {
             $termFilter = Arr::except($filter, $term);
 
-            // Additionally exclude date_latest for date_earliest and vice versa
+            // Exclude date_latest for date_earliest and vice versa
             if ($term === 'date_earliest') {
                 $termFilter = Arr::except($termFilter, 'date_latest');
             }
@@ -149,9 +149,7 @@ class ItemController extends Controller
                 ],
             ]);
 
-        $searchResponse = collect(
-            Arr::get($searchRequest->execute()->raw(), 'aggregations.all_items')
-        )
+        return collect(Arr::get($searchRequest->execute()->raw(), 'aggregations.all_items'))
             ->only(array_keys($aggregationsQuery))
             ->map(function (array $aggregation) {
                 if (Arr::has($aggregation, 'filtered.value')) {
@@ -165,21 +163,6 @@ class ItemController extends Controller
                     ]
                 );
             });
-
-        // Ensure filtered (i.e. selected) terms are included in the response
-        foreach ($filter as $term => $value) {
-            if (!Arr::has($terms, $term)) {
-                continue;
-            }
-
-            foreach (Arr::wrap($value) as $value) {
-                if (!$searchResponse[$term]->contains('value', $value)) {
-                    $searchResponse[$term]->prepend(['value' => $value, 'count' => 0])->pop();
-                }
-            }
-        }
-
-        return $searchResponse;
     }
 
     public function detail(Request $request, $id)

--- a/app/Http/Controllers/Api/V1/ItemController.php
+++ b/app/Http/Controllers/Api/V1/ItemController.php
@@ -102,21 +102,21 @@ class ItemController extends Controller
 
         $aggregationsQuery = [];
 
-        foreach ($terms as $agg => $field) {
-            $aggregationsQuery[$agg]['aggregations']['filtered']['terms'] = [
+        foreach ($terms as $aggregationName => $field) {
+            $aggregationsQuery[$aggregationName]['aggregations']['filtered']['terms'] = [
                 'field' => $field,
                 'size' => $size,
             ];
         }
 
-        foreach ($min as $agg => $field) {
-            $aggregationsQuery[$agg]['aggregations']['filtered']['min'] = [
+        foreach ($min as $aggregationName => $field) {
+            $aggregationsQuery[$aggregationName]['aggregations']['filtered']['min'] = [
                 'field' => $field,
             ];
         }
 
-        foreach ($max as $agg => $field) {
-            $aggregationsQuery[$agg]['aggregations']['filtered']['max'] = [
+        foreach ($max as $aggregationName => $field) {
+            $aggregationsQuery[$aggregationName]['aggregations']['filtered']['max'] = [
                 'field' => $field,
             ];
         }
@@ -131,7 +131,7 @@ class ItemController extends Controller
         }
 
         $searchRequest = Item::searchQuery()
-            ->size(0)
+            ->size(0) // No documents are needed, only aggregations
             ->aggregateRaw([
                 'all_items' => [
                     'global' => (object) [],
@@ -162,7 +162,7 @@ class ItemController extends Controller
                 continue;
             }
 
-            foreach (array_reverse(Arr::wrap($value)) as $value) {
+            foreach (Arr::wrap($value) as $value) {
                 if (!$searchResponse[$term]->contains('value', $value)) {
                     $searchResponse[$term]->prepend(['value' => $value, 'count' => 0])->pop();
                 }

--- a/app/Http/Controllers/Api/V1/ItemController.php
+++ b/app/Http/Controllers/Api/V1/ItemController.php
@@ -122,6 +122,7 @@ class ItemController extends Controller
         }
 
         // Add filter terms to each aggregation
+        // Based on https://madewithlove.com/blog/faceted-search-using-elasticsearch/
         foreach (array_keys($aggregationsQuery) as $term) {
             $aggregationsQuery[$term]['filter'] = $this->createQueryBuilder(
                 $q,

--- a/routes/api.php
+++ b/routes/api.php
@@ -27,7 +27,9 @@ Route::prefix('v1')
     ->name('api.v1.')
     ->group(function () {
         Route::get('items', [V1ItemController::class, 'index'])->name('items.index');
-        Route::get('items/aggregations', [V1ItemController::class, 'aggregations']);
+        Route::get('items/aggregations', [V1ItemController::class, 'aggregations'])->name(
+            'items.aggregations'
+        );
         Route::get('items/{id}', [V1ItemController::class, 'detail'])->name('items.show');
     });
 

--- a/tests/Feature/Api/V1/ItemsAggregationsTest.php
+++ b/tests/Feature/Api/V1/ItemsAggregationsTest.php
@@ -129,14 +129,4 @@ class ItemsAggregationsTest extends TestCase
             ])['topic']
         );
     }
-
-    public function test_selected_facet_value_is_always_present()
-    {
-        $this->getAggregations([
-            'filter' => ['topic' => ['spring'], 'author' => ['Wouwerman, Philips']],
-            'terms' => ['topic' => 'topic', 'author' => 'author'],
-        ])
-            ->assertJsonFragment(['value' => 'spring', 'count' => 0])
-            ->assertJsonFragment(['value' => 'Wouwerman, Philips', 'count' => 0]);
-    }
 }

--- a/tests/Feature/Api/V1/ItemsAggregationsTest.php
+++ b/tests/Feature/Api/V1/ItemsAggregationsTest.php
@@ -25,7 +25,7 @@ class ItemsAggregationsTest extends TestCase
 
         Item::factory()->createMany([
             [
-                'author' => 'Wouwerman, Philips',
+                'author' => 'Galanda, Mikuláš',
                 'topic' => 'spring',
                 'date_earliest' => 1000,
             ],
@@ -55,7 +55,10 @@ class ItemsAggregationsTest extends TestCase
     public function test_shows_terms()
     {
         $this->getAggregations(['terms' => ['my_author' => 'author']])->assertExactJson([
-            'my_author' => [['value' => 'Wouwerman, Philips', 'count' => 2]],
+            'my_author' => [
+                ['value' => 'Galanda, Mikuláš', 'count' => 1],
+                ['value' => 'Wouwerman, Philips', 'count' => 1],
+            ],
         ]);
     }
 
@@ -106,5 +109,15 @@ class ItemsAggregationsTest extends TestCase
                 'size' => 2,
             ])['topic']
         );
+    }
+
+    public function test_selected_facet_value_is_always_present()
+    {
+        $this->getAggregations([
+            'filter' => ['topic' => ['spring'], 'author' => ['Wouwerman, Philips']],
+            'terms' => ['topic' => 'topic', 'author' => 'author'],
+        ])
+            ->assertJsonFragment(['value' => 'spring', 'count' => 0])
+            ->assertJsonFragment(['value' => 'Wouwerman, Philips', 'count' => 0]);
     }
 }

--- a/tests/Feature/Api/V1/ItemsAggregationsTest.php
+++ b/tests/Feature/Api/V1/ItemsAggregationsTest.php
@@ -42,7 +42,8 @@ class ItemsAggregationsTest extends TestCase
 
     private function getAggregations(array $params = [])
     {
-        $url = route('api.v1.items.aggregations', $params);
+        $defaultParams = ['size' => 10];
+        $url = route('api.v1.items.aggregations', array_merge($defaultParams, $params));
         return $this->getJson($url);
     }
 
@@ -67,6 +68,15 @@ class ItemsAggregationsTest extends TestCase
             'author' => [['value' => 'Wouwerman, Philips', 'count' => 1]],
         ]);
     }
+    public function test_filtered_faced_does_not_affect_itself()
+    {
+        $this->getAggregations([
+            'filter' => ['topic' => ['summer']],
+            'terms' => ['topic' => 'topic'],
+        ])->assertExactJson([
+            'topic' => [['value' => 'spring', 'count' => 1], ['value' => 'summer', 'count' => 1]],
+        ]);
+    }
 
     public function test_gets_min_and_max()
     {
@@ -84,6 +94,7 @@ class ItemsAggregationsTest extends TestCase
         $this->assertCount(
             1,
             $this->getAggregations([
+                'size' => null, // reset to default
                 'terms' => ['topic' => 'topic'],
             ])['topic']
         );

--- a/tests/Feature/Api/V1/ItemsAggregationsTest.php
+++ b/tests/Feature/Api/V1/ItemsAggregationsTest.php
@@ -28,11 +28,13 @@ class ItemsAggregationsTest extends TestCase
                 'author' => 'Galanda, Mikuláš',
                 'topic' => 'spring',
                 'date_earliest' => 1000,
+                'date_latest' => 1000,
             ],
             [
                 'author' => 'Wouwerman, Philips',
                 'topic' => 'summer',
                 'date_earliest' => 2000,
+                'date_latest' => 2000,
             ],
         ]);
 
@@ -78,6 +80,23 @@ class ItemsAggregationsTest extends TestCase
             'terms' => ['topic' => 'topic'],
         ])->assertExactJson([
             'topic' => [['value' => 'spring', 'count' => 1], ['value' => 'summer', 'count' => 1]],
+        ]);
+    }
+
+    public function test_filtered_date_field_does_not_affect_other_date_fields()
+    {
+        $this->getAggregations([
+            'filter' => ['date_earliest' => ['gte' => 2000]],
+            'terms' => ['date_latest' => 'date_latest'],
+        ])->assertExactJson([
+            'date_latest' => [['value' => 1000, 'count' => 1], ['value' => 2000, 'count' => 1]],
+        ]);
+
+        $this->getAggregations([
+            'filter' => ['date_latest' => ['gte' => 2000]],
+            'terms' => ['date_earliest' => 'date_earliest'],
+        ])->assertExactJson([
+            'date_earliest' => [['value' => 1000, 'count' => 1], ['value' => 2000, 'count' => 1]],
         ]);
     }
 

--- a/tests/Feature/Api/V1/ItemsAggregationsTest.php
+++ b/tests/Feature/Api/V1/ItemsAggregationsTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Tests\Feature\Api\V1;
+
+use App\Elasticsearch\Repositories\ItemRepository;
+use App\Item;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\RecreateSearchIndex;
+use Tests\TestCase;
+
+class ItemsAggregationsTest extends TestCase
+{
+    use RefreshDatabase;
+    use RecreateSearchIndex;
+
+    private $initialized = false;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        if ($this->initialized) {
+            return;
+        }
+
+        Item::factory()->createMany([
+            [
+                'author' => 'Wouwerman, Philips',
+                'topic' => 'spring',
+                'date_earliest' => 1000,
+            ],
+            [
+                'author' => 'Wouwerman, Philips',
+                'topic' => 'summer',
+                'date_earliest' => 2000,
+            ],
+        ]);
+
+        app(ItemRepository::class)->refreshIndex();
+        $this->initialized = true;
+    }
+
+    private function getAggregations(array $params = [])
+    {
+        $url = route('api.v1.items.aggregations', $params);
+        return $this->getJson($url);
+    }
+
+    public function test_shows_nothing_by_default()
+    {
+        $this->getAggregations()->assertExactJson([]);
+    }
+
+    public function test_shows_terms()
+    {
+        $this->getAggregations(['terms' => ['my_author' => 'author']])->assertExactJson([
+            'my_author' => [['value' => 'Wouwerman, Philips', 'count' => 2]],
+        ]);
+    }
+
+    public function test_filters_results()
+    {
+        $this->getAggregations([
+            'filter' => ['topic' => ['summer']],
+            'terms' => ['author' => 'author'],
+        ])->assertExactJson([
+            'author' => [['value' => 'Wouwerman, Philips', 'count' => 1]],
+        ]);
+    }
+
+    public function test_gets_min_and_max()
+    {
+        $this->getAggregations([
+            'min' => ['date_earliest_min' => 'date_earliest'],
+            'max' => ['date_earliest_max' => 'date_earliest'],
+        ])->assertExactJson([
+            'date_earliest_min' => 1000,
+            'date_earliest_max' => 2000,
+        ]);
+    }
+
+    public function test_size_limits_number_of_buckets()
+    {
+        $this->assertCount(
+            1,
+            $this->getAggregations([
+                'terms' => ['topic' => 'topic'],
+            ])['topic']
+        );
+
+        $this->assertCount(
+            2,
+            $this->getAggregations([
+                'terms' => ['topic' => 'topic'],
+                'size' => 2,
+            ])['topic']
+        );
+    }
+}


### PR DESCRIPTION
* added tests
* facet now does not affect itself (but just other facets)
* filtered (i.e. selected) value are always included in the aggregation results, so that they don't disappear


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have updated the [CHANGELOG](../CHANGELOG.md)
- [x] I have requested at least 1 reviewer for this PR
- [ ] I have made corresponding changes to the documentation
