### PR TITLE
feat: add role to authorities for items

### DIFF
--- a/app/Http/Resources/Api/V2/AuthorityResource.php
+++ b/app/Http/Resources/Api/V2/AuthorityResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Resources\Api\V2;
 
+use App\Authority;
 use Illuminate\Http\Resources\Json\JsonResource;
 
 class AuthorityResource extends JsonResource
@@ -23,6 +24,7 @@ class AuthorityResource extends JsonResource
             'death_place' => $this->death_place,
             'birth_date' => $this->birth_date,
             'death_date' => $this->death_date,
+            'role' => Authority::formatMultiAttribute($this->pivot->role),
             'image_path' => $this->getImagePath(),
         ];
     }

--- a/tests/Feature/Api/V2/ItemsTest.php
+++ b/tests/Feature/Api/V2/ItemsTest.php
@@ -28,7 +28,7 @@ class ItemsTest extends TestCase
             'image_ratio' => 1.5,
         ]);
 
-        $item->authorities()->attach($authority);
+        $item->authorities()->attach($authority, ['role' => 'autor/author']);
         $item_image->item()->associate($item);
         $item_image->save();
 
@@ -51,6 +51,7 @@ class ItemsTest extends TestCase
                             'death_place',
                             'image_path',
                         ]),
+                        'role' => 'autor',
                         'image_path' => $authority->getImagePath(),
                     ],
                 ],


### PR DESCRIPTION
Route: `api/v2/items/{item_id}`
Sample Result: 
`{data: {..., authorites: {... role: 'author/author'}}}`