### PR TITLE
fix infinite artwork carousel

### DIFF
--- a/public/js/components/artwork_carousel.js
+++ b/public/js/components/artwork_carousel.js
@@ -3,7 +3,7 @@ $(document).ready(function(){
     lazyLoad: 'progressive',
     slide: 'a',
     variableWidth: true,
-    infinite: true
+    infinite: false
   });
   $(".multiple-views").slick({
     lazyLoad: 'progressive',


### PR DESCRIPTION
https://jira.sng.sk/browse/WEBUMENIA-1978

This problem occurs anywhere if there's insufficient number of carousel items. `infinite` setting doesn't go well with `variableWidth` here.

https://www.webumenia.sk/dielo/SVK:SGB.K_2112
https://www.webumenia.sk/autori?page=200
https://www.webumenia.sk/autor/3502