### PR TITLE
Support showing of more than 10 related works in zoom view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file[^1].
 ## [Unreleased]
 ### Fixed
 - indexing of Admin section
+- Zoom viewer for more than 10 related images
 
 ## [2.85.0] - 2023-11-23
 ### Changed

--- a/app/Http/Controllers/ZoomController.php
+++ b/app/Http/Controllers/ZoomController.php
@@ -7,7 +7,7 @@ use App\ItemImage;
 
 class ZoomController extends Controller
 {
-   /**
+    /**
      * Show the zoomable itemImages for the item with specified $id
      *
      * @param  int  $id
@@ -20,10 +20,14 @@ class ZoomController extends Controller
             ->findOrFail($id);
 
         $itemImages = $item->images;
-        $index =  0;
-        
+        $index = 0;
+
         if ($itemImages->count() === 1 && $item->related_work) {
-            $relatedItems = Item::related($item)->has('images')->with('images')->get();
+            $relatedItems = $item
+                ->related()
+                ->has('images')
+                ->with('images')
+                ->get();
 
             $itemImages = $relatedItems->map(function ($relatedItem) {
                 return $relatedItem->images->first();

--- a/app/Item.php
+++ b/app/Item.php
@@ -609,12 +609,12 @@ class Item extends Model implements IndexableModel, TranslatableContract
         return $query->where('has_image', '=', $hasImage);
     }
 
-    public function related($limit = 10)
+    public function related()
     {
         $relatedIds = Item::search()
             ->where('related_work', $this->related_work)
             ->whereIn('author', $this->makeArray($this->author))
-            ->take($limit)
+            ->take(1000) // Scout limits to 10 by default
             ->keys();
 
         return self::query()

--- a/app/Item.php
+++ b/app/Item.php
@@ -609,14 +609,17 @@ class Item extends Model implements IndexableModel, TranslatableContract
         return $query->where('has_image', '=', $hasImage);
     }
 
-    public function scopeRelated($query, Item $item)
+    public function related($limit = 10)
     {
         $relatedIds = Item::search()
-            ->where('related_work', $item->related_work)
-            ->whereIn('author', $this->makeArray($item->author))
+            ->where('related_work', $this->related_work)
+            ->whereIn('author', $this->makeArray($this->author))
+            ->take($limit)
             ->keys();
 
-        return $query->whereIn('id', $relatedIds)->orderBy('related_work_order');
+        return self::query()
+            ->whereIn('id', $relatedIds)
+            ->orderBy('related_work_order');
     }
 
     public function getAuthorsWithLinks()

--- a/resources/js/components/ZoomViewerThumbnail.vue
+++ b/resources/js/components/ZoomViewerThumbnail.vue
@@ -1,0 +1,17 @@
+<template>
+    <img ref="img" @load="onLoad" @click="$emit('click')" />
+</template>
+
+<script>
+export default {
+    props: {
+        scrollIntoView: Boolean,
+    },
+    methods: {
+        onLoad() {
+            if (!this.scrollIntoView) return
+            this.$refs.img.scrollIntoView()
+        },
+    },
+}
+</script>

--- a/resources/js/zoom.js
+++ b/resources/js/zoom.js
@@ -4,5 +4,6 @@ import VueDragscroll from 'vue-dragscroll'
 Vue.use(VueDragscroll)
 
 Vue.component('zoom-viewer', require('./components/ZoomViewer.vue').default)
+Vue.component('zoom-viewer.thumbnail', require('./components/ZoomViewerThumbnail.vue').default)
 
 new Vue({ el: '#app' })

--- a/resources/js/zoom.js
+++ b/resources/js/zoom.js
@@ -1,9 +1,11 @@
-import Vue from 'vue'
+import { createApp } from 'vue'
 import VueDragscroll from 'vue-dragscroll'
 
-Vue.use(VueDragscroll)
+const app = createApp({})
 
-Vue.component('zoom-viewer', require('./components/ZoomViewer.vue').default)
-Vue.component('zoom-viewer.thumbnail', require('./components/ZoomViewerThumbnail.vue').default)
+app.use(VueDragscroll)
 
-new Vue({ el: '#app' })
+app.component('zoom-viewer', require('./components/ZoomViewer.vue').default)
+app.component('zoom-viewer.thumbnail', require('./components/ZoomViewerThumbnail.vue').default)
+
+app.mount('#app')

--- a/resources/views/zoom.blade.php
+++ b/resources/views/zoom.blade.php
@@ -57,21 +57,21 @@
                             <div v-if="showControls"
                                 class="tw-hidden tw-space-x-1.5 tw-text-lg md:tw-block">
                                 <button v-on:click="methods.zoomIn"
-                                    class="tw-pointer-events-auto tw-h-10 tw-w-10 tw-bg-white tw-opacity-70 tw-transition-opacity hover:tw-opacity-90 active:tw-bg-white disabled:tw-opacity-30">
+                                    class="tw-pointer-events-auto tw-h-10 tw-w-10 tw-bg-white tw-opacity-70 tw-transition-opacity disabled:tw-opacity-30 hover:tw-opacity-90 active:tw-bg-white">
                                     <i class="fa fa-plus"></i>
                                 </button>
                                 <button v-on:click="methods.zoomOut"
-                                    class="tw-pointer-events-auto tw-h-10 tw-w-10 tw-bg-white tw-opacity-70 tw-transition-opacity hover:tw-opacity-90 active:tw-bg-white disabled:tw-opacity-30">
+                                    class="tw-pointer-events-auto tw-h-10 tw-w-10 tw-bg-white tw-opacity-70 tw-transition-opacity disabled:tw-opacity-30 hover:tw-opacity-90 active:tw-bg-white">
                                     <i class="fa fa-minus"></i>
                                 </button>
                                 <button v-if="sequenceMode" v-on:click="methods.previousPage"
                                     :disabled="page === 0"
-                                    class="tw-pointer-events-auto tw-h-10 tw-w-10 tw-bg-white tw-opacity-70 tw-transition-opacity hover:tw-opacity-90 active:tw-bg-white disabled:tw-opacity-30">
+                                    class="tw-pointer-events-auto tw-h-10 tw-w-10 tw-bg-white tw-opacity-70 tw-transition-opacity disabled:tw-opacity-30 hover:tw-opacity-90 active:tw-bg-white">
                                     <i class="fa fa-arrow-up"></i>
                                 </button>
                                 <button v-if="sequenceMode" v-on:click="methods.nextPage"
                                     :disabled="page === thumbnailUrls.length - 1"
-                                    class="tw-pointer-events-auto tw-h-10 tw-w-10 tw-bg-white tw-opacity-70 tw-transition-opacity hover:tw-opacity-90 active:tw-bg-white disabled:tw-opacity-30">
+                                    class="tw-pointer-events-auto tw-h-10 tw-w-10 tw-bg-white tw-opacity-70 tw-transition-opacity disabled:tw-opacity-30 hover:tw-opacity-90 active:tw-bg-white">
                                     <i class="fa fa-arrow-down"></i>
                                 </button>
                             </div>

--- a/resources/views/zoom.blade.php
+++ b/resources/views/zoom.blade.php
@@ -104,8 +104,9 @@
 
                     <div v-dragscroll v-show="showControls" v-if="sequenceMode"
                         class="tw-pointer-events-auto tw-flex tw-h-20 tw-flex-shrink-0 tw-overflow-auto tw-bg-white tw-bg-opacity-70 md:tw-h-full md:tw-w-32 md:tw-flex-col">
-                        <img v-for="src, index in thumbnailUrls" :key="index" :src="src"
-                            v-on:click="methods.setPage(index)"
+                        <zoom-viewer.thumbnail v-for="src, index in thumbnailUrls" :key="index"
+                            :scroll-into-view="index === {{ $index }}" :src="src"
+                            loading="lazy" v-on:click="methods.setPage(index)"
                             :class="['tw-h-full md:tw-h-auto tw-p-2 md:tw-px-4 tw-border tw-cursor-pointer tw-transition-colors tw-border-sky-300', page === index ? 'tw-border-opacity-100' : 'tw-border-transparent hover:tw-border-sky-300/30']" />
                     </div>
                 </Transition>

--- a/routes/web.php
+++ b/routes/web.php
@@ -252,6 +252,7 @@ function()
             ? $item
                 ->related()
                 ->with('translations')
+                ->take(10)
                 ->get()
             : null;
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -249,8 +249,9 @@ function()
             )
             ->get();
         $related_items = !empty($item->related_work)
-            ? Item::with('translations')
-                ->related($item)
+            ? $item
+                ->related()
+                ->with('translations')
                 ->get()
             : null;
 


### PR DESCRIPTION
- `Item::related` has changed to (dynamic) `Item#related` which is not limited by default
- Thumbnails in ZoomViewer are loaded lazily so that the first paint is fairly quick
- zoom.js bootstrapper has been re-factored into Vue 3 style to silence warnings

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have updated the [CHANGELOG](../CHANGELOG.md)
- [ ] I have requested at least 1 reviewer for this PR
- [ ] I have made corresponding changes to the documentation
