### PR TITLE
Fix BottomModal variant of the newsletter signup form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file[^1].
 
 ## [Unreleased]
+### Fixed
+- BottomModal variant of the newsletter signup form
 
 ## [2.86.0] - 2023-12-07
 ### Fixed

--- a/resources/js/components/UserInteractionContext.vue
+++ b/resources/js/components/UserInteractionContext.vue
@@ -23,7 +23,7 @@ export default {
     mounted() {
         window.addEventListener('scroll', this.onScrollDebounced);
     },
-    beforeDestroy() {
+    beforeUnmount() {
         clearInterval(this.timeSpentInterval);
         window.removeEventListener('scroll', this.onScrollDebounced);
     },

--- a/resources/views/livewire/newsletter-signup-form-bottom-modal.blade.php
+++ b/resources/views/livewire/newsletter-signup-form-bottom-modal.blade.php
@@ -5,8 +5,9 @@
                 interaction.maxScrolledPercent >= {{ $openOnScrolledPercent }}
                 && interaction.timeSpentSeconds >= 30
             "
-            v-on:open="lw.call('onOpen')"
-            v-on:close="lw.call('onDismissed')"
+            {{-- TODO tracking disabled WEBUMENIA-2042 --}}
+            {{-- v-on:open="lw.call('onOpen')" --}}
+            {{-- v-on:close="lw.call('onDismissed')" --}}
         >
             <div class="row py-5">
                 <div class="visible-lg-block col-lg-1 col-lg-offset-2 text-right pl-0 pt-4">

--- a/resources/views/livewire/newsletter-signup-form.blade.php
+++ b/resources/views/livewire/newsletter-signup-form.blade.php
@@ -39,7 +39,7 @@
                 </form>
                 <div class="text-sm mt-3 mb-md-0 text-dark">
                     {!! __('general.newsletter_sign_up.privacy_policy.blurb') !!}
-                    <a href="https://www.sng.sk/sk/o-galerii/dokumenty/gdpr" target="_blank" class="underline">{{ __('general.newsletter_sign_up.privacy_policy.link') }}</a>.
+                    <a href="https://sng.sk/sk/sng-bratislava/stranka/gdpr" target="_blank" class="underline">{{ __('general.newsletter_sign_up.privacy_policy.link') }}</a>.
                 </div>
             </div>
         </div>


### PR DESCRIPTION
by disabling its tracking callbacks. These no longer seem compatible (with Vue3) and will be re-enabled as part of WEBUMENIA-2042, where we move away from Livewire

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have updated the [CHANGELOG](../CHANGELOG.md)
- [x] I have requested at least 1 reviewer for this PR
- [ ] I have made corresponding changes to the documentation
