### PR TITLE
[api] fix v1 item detail

### DIFF
--- a/app/Http/Controllers/Api/V1/ItemController.php
+++ b/app/Http/Controllers/Api/V1/ItemController.php
@@ -174,11 +174,11 @@ class ItemController extends Controller
         $filter = (array) $request->get('filter');
         $q = (string) $request->get('q');
 
-        try {
+        if ($q || $filter) {
             $query = $this->createQueryBuilder($q, $filter)
                 ->must(Query::ids()->values([$id]))
                 ->buildQuery();
-        } catch (QueryBuilderException $e) {
+        } else {
             $query = Query::ids()->values([$id]);
         }
 


### PR DESCRIPTION
 Currently `createQueryBuilder` without `$q` or `$filter` returns `MatchAllQueryBuilder`

https://slovak-national-gallery.sentry.io/issues/4573688345/?project=5540820 