### PR TITLE
Enable search and aggregations combining authors with and without authority_id 

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -16,7 +16,7 @@ jobs:
           - 3306
 
       elasticsearch:
-        image: ghcr.io/slovaknationalgallery/elasticsearch-webumenia:7.3.1
+        image: ghcr.io/slovaknationalgallery/elasticsearch-webumenia:7.17.3
         env:
           discovery.type: single-node
         ports:

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ It requires
 
 -   PHP 8.1
 -   MySQL 8.0
--   Elasticsearch 7.3
+-   Elasticsearch 7.17
 
 We also provide a [Dockerfile](Dockerfile) and [docker-compose.yml](docker-compose.yml) with a basic stack set-up.
 

--- a/app/Http/Controllers/Api/V1/ItemController.php
+++ b/app/Http/Controllers/Api/V1/ItemController.php
@@ -17,6 +17,7 @@ class ItemController extends Controller
 {
     private $filterables = [
         'author',
+        'authority_id',
         'topic',
         'work_type',
         'medium',

--- a/app/Http/Controllers/Api/V1/ItemController.php
+++ b/app/Http/Controllers/Api/V1/ItemController.php
@@ -96,6 +96,9 @@ class ItemController extends Controller
                         'authors_formatted' => collect($document['content']['author'])->map(
                             fn($author) => formatName($author)
                         ),
+                        'authors' => collect($document['content']['authors'])->map(
+                            fn($a) => [...$a, 'name_formatted' => formatName($a['name'])]
+                        ),
                     ],
                 ]
             ),
@@ -246,9 +249,6 @@ class ItemController extends Controller
                     'inscription',
                     'acquisition_date',
                 ]),
-                'authors' => collect($document['content']['authors'])->map(
-                    fn($a) => [...$a, 'name_formatted' => formatName($a['name'])]
-                ),
             ],
         ];
     }

--- a/app/Item.php
+++ b/app/Item.php
@@ -389,7 +389,8 @@ class Item extends Model implements IndexableModel, TranslatableContract
         $authors = $this
             ->getAuthorsWithoutAuthority()
             ->map(fn ($author) => (object) [
-                'name' => $author
+                'name' => $author,
+                'authority' => null
             ]);
 
         return $authorities->concat($authors);
@@ -398,11 +399,8 @@ class Item extends Model implements IndexableModel, TranslatableContract
 
     public function getUniqueAuthorsWithAuthorityNames()
     {
-        return $this->authorities
+        return $this->authors_with_authorities
             ->pluck('name')
-            ->merge($this->getAuthorsWithoutAuthority())
-            ->filter() // hotfix: names should be filled
-            ->values()
             ->toArray();
     }
 
@@ -478,7 +476,7 @@ class Item extends Model implements IndexableModel, TranslatableContract
             return $formated;
         }
         $trans = [
-            "/" => "–", 
+            "/" => "–",
             "-" => "–",
         ];
         if ($multi_line) {
@@ -720,6 +718,12 @@ class Item extends Model implements IndexableModel, TranslatableContract
             'id' => $this->id,
             'identifier' => $this->identifier,
             'author' => $this->getUniqueAuthorsWithAuthorityNames(),
+            'authors' => $this->authors_with_authorities->map(
+                fn($a) => [
+                    'name' => $a->name,
+                    'authority' => $a->authority ? $a->authority->only(['id']) : null,
+                ]
+            ),
             'tag' => $this->tagNames(), // @TODO translate model
             'date_earliest' => $this->date_earliest,
             'date_latest' => $this->date_latest,

--- a/config/elasticsearch/mapping/items.php
+++ b/config/elasticsearch/mapping/items.php
@@ -17,17 +17,20 @@ $mapping = [
                     'type' => 'text',
                     'analyzer' => 'autocomplete_analyzer',
                     'search_analyzer' => 'asciifolding_analyzer',
-                ]
-            ]
+                ],
+            ],
+        ],
+        'authors' => [
+            'type' => 'nested',
         ],
         'authority_id' => [
             'type' => 'keyword',
         ],
         'color_descriptor' => [
-            'type' => 'float'
+            'type' => 'float',
         ],
         'contributor' => [
-            'type' => 'keyword'
+            'type' => 'keyword',
         ],
         'created_at' => [
             'type' => 'date',
@@ -52,8 +55,8 @@ $mapping = [
                 'stemmed' => [
                     'type' => 'text',
                     'analyzer' => 'default_analyzer',
-                ]
-            ]
+                ],
+            ],
         ],
         'free_download' => [
             'type' => 'boolean',
@@ -71,7 +74,7 @@ $mapping = [
             'type' => 'boolean',
         ],
         'image_ratio' => [
-            'type' => 'float'
+            'type' => 'float',
         ],
         'id' => [
             'type' => 'keyword',
@@ -93,9 +96,9 @@ $mapping = [
             'fields' => [
                 'folded' => [
                     'type' => 'text',
-                    'analyzer' => 'asciifolding_analyzer'
-                ]
-            ]
+                    'analyzer' => 'asciifolding_analyzer',
+                ],
+            ],
         ],
         'related_work' => [
             'type' => 'keyword',
@@ -110,8 +113,8 @@ $mapping = [
                 'stemmed' => [
                     'type' => 'text',
                     'analyzer' => 'default_analyzer',
-                ]
-            ]
+                ],
+            ],
         ],
         'technique' => [
             'type' => 'keyword',
@@ -131,8 +134,8 @@ $mapping = [
                     'type' => 'text',
                     'analyzer' => 'autocomplete_analyzer',
                     'search_analyzer' => 'asciifolding_analyzer',
-                ]
-            ]
+                ],
+            ],
         ],
         'topic' => [
             'type' => 'keyword',
@@ -140,8 +143,8 @@ $mapping = [
                 'folded' => [
                     'type' => 'text',
                     'analyzer' => 'asciifolding_analyzer',
-                ]
-            ]
+                ],
+            ],
         ],
         'updated_at' => [
             'type' => 'date',
@@ -164,7 +167,7 @@ $mapping = [
             'type' => 'nested',
         ],
         'additionals' => [
-            'type' => 'object'
+            'type' => 'object',
         ],
         'images' => [
             'type' => 'keyword',

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   web:
     image: nginx:latest
     ports:
-      - "8080:80"
+      - '8080:80'
     volumes:
       - .:/var/www
       - ./nginx.conf:/etc/nginx/conf.d/default.conf
@@ -33,10 +33,10 @@ services:
       MYSQL_ALLOW_EMPTY_PASSWORD: 1
 
   elasticsearch:
-    image: ghcr.io/slovaknationalgallery/elasticsearch-webumenia:7.3.1
+    image: ghcr.io/slovaknationalgallery/elasticsearch-webumenia:7.17.3
     environment:
       - discovery.type=single-node
-      - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
+      - 'ES_JAVA_OPTS=-Xms1g -Xmx1g'
     ulimits:
       memlock:
         soft: -1

--- a/tests/Feature/Api/V1/ItemsAggregationsTest.php
+++ b/tests/Feature/Api/V1/ItemsAggregationsTest.php
@@ -129,4 +129,18 @@ class ItemsAggregationsTest extends TestCase
             ])['topic']
         );
     }
+
+    public function test_search_for_authors_with_same_name()
+    {
+        $authorSameName = Item::factory()->create([
+            'author' => 'Galanda, Mikuláš',
+        ]);
+
+        $this->getAggregations([
+            'filter' => ['author_id' => [1]],
+            'terms' => ['author' => 'author'],
+        ])->assertExactJson([
+            'author' => [['value' => 'Galanda, Mikuláš', 'count' => 1]],
+        ]);
+    }
 }

--- a/tests/Feature/Api/V1/ItemsAggregationsTest.php
+++ b/tests/Feature/Api/V1/ItemsAggregationsTest.php
@@ -144,7 +144,7 @@ class ItemsAggregationsTest extends TestCase
         app(ItemRepository::class)->refreshIndex();
 
         $this->getAggregations([
-            'filter' => ['authors' => ['name' => 'Galanda, Mikuláš']],
+            'filter' => ['authors.name' => ['Galanda, Mikuláš']],
             'terms' => ['authors' => 'authors'],
         ])->assertSimilarJson([
             'authors' => [

--- a/tests/Feature/Api/V1/ItemsAggregationsTest.php
+++ b/tests/Feature/Api/V1/ItemsAggregationsTest.php
@@ -146,11 +146,19 @@ class ItemsAggregationsTest extends TestCase
         $this->getAggregations([
             'filter' => ['authors' => ['name' => 'Galanda, Mikuláš']],
             'terms' => ['authors' => 'authors'],
-        ])->assertExactJson([
-            'author' => [
-                ['value' => 'Galanda, Mikuláš', 'authority_id' => $author1->id, 'count' => 1],
-                ['value' => 'Galanda, Mikuláš', 'authority_id' => $author2->id, 'count' => 1],
-                ['value' => 'Wouwerman, Philips', 'authority_id' => null, 'count' => 1],
+        ])->assertSimilarJson([
+            'authors' => [
+                [
+                    'name' => 'Galanda, Mikuláš',
+                    'authority' => ['id' => $author1->id],
+                    'count' => 1,
+                ],
+                [
+                    'name' => 'Galanda, Mikuláš',
+                    'authority' => ['id' => $author2->id],
+                    'count' => 1,
+                ],
+                ['name' => 'Wouwerman, Philips', 'authority' => null, 'count' => 1],
             ],
         ]);
     }

--- a/tests/Feature/Api/V1/ItemsAggregationsTest.php
+++ b/tests/Feature/Api/V1/ItemsAggregationsTest.php
@@ -144,13 +144,13 @@ class ItemsAggregationsTest extends TestCase
         app(ItemRepository::class)->refreshIndex();
 
         $this->getAggregations([
-            'filter' => ['author' => 'Galanda, Mikuláš'],
-            'terms' => ['author' => 'author'],
+            'filter' => ['authors' => ['name' => 'Galanda, Mikuláš']],
+            'terms' => ['authors' => 'authors'],
         ])->assertExactJson([
             'author' => [
-                ['value' => 'Galanda, Mikuláš', 'id' => $author1->id, 'count' => 1],
-                ['value' => 'Galanda, Mikuláš', 'id' => $author2->id, 'count' => 1],
-                ['value' => 'Wouwerman, Philips', 'id' => null, 'count' => 1],
+                ['value' => 'Galanda, Mikuláš', 'authority_id' => $author1->id, 'count' => 1],
+                ['value' => 'Galanda, Mikuláš', 'authority_id' => $author2->id, 'count' => 1],
+                ['value' => 'Wouwerman, Philips', 'authority_id' => null, 'count' => 1],
             ],
         ]);
     }

--- a/tests/Feature/Api/V1/ItemsTest.php
+++ b/tests/Feature/Api/V1/ItemsTest.php
@@ -123,7 +123,6 @@ class ItemsTest extends TestCase
 
         $searchById = route('api.v1.items.index', [
             'size' => 10,
-            'filter[author]' => 'Věšín, Jaroslav',
             'filter[authority_id]' => $author1->id,
         ]);
 

--- a/tests/Feature/Api/V1/ItemsTest.php
+++ b/tests/Feature/Api/V1/ItemsTest.php
@@ -224,7 +224,7 @@ class ItemsTest extends TestCase
             ->assertJsonPath('data.0.id', $similar->id);
     }
 
-    public function test_detail()
+    public function test_authors_field()
     {
         $authorWithAuthority = Authority::factory()->create([
             'id' => 'authority-id',
@@ -241,24 +241,28 @@ class ItemsTest extends TestCase
         app(ItemRepository::class)->refreshIndex();
 
         $response = $this->getJson(
-            route('api.v1.items.show', [
-                'id' => 'item-id',
+            route('api.v1.items.index', [
+                'size' => 100,
             ])
         );
 
         $response->assertJson([
-            'id' => 'item-id',
-            'content' => [
-                'authors' => [
-                    [
-                        'name' => 'Věšín, Jaroslav',
-                        'name_formatted' => 'Jaroslav Věšín',
-                        'authority' => ['id' => 'authority-id'],
-                    ],
-                    [
-                        'name' => 'Viedenský maliar z konca 18. storočia',
-                        'name_formatted' => 'Viedenský maliar z konca 18. storočia',
-                        'authority' => null,
+            'data' => [
+                [
+                    'id' => 'item-id',
+                    'content' => [
+                        'authors' => [
+                            [
+                                'name' => 'Věšín, Jaroslav',
+                                'name_formatted' => 'Jaroslav Věšín',
+                                'authority' => ['id' => 'authority-id'],
+                            ],
+                            [
+                                'name' => 'Viedenský maliar z konca 18. storočia',
+                                'name_formatted' => 'Viedenský maliar z konca 18. storočia',
+                                'authority' => null,
+                            ],
+                        ],
                     ],
                 ],
             ],

--- a/tests/Feature/Api/V1/ItemsTest.php
+++ b/tests/Feature/Api/V1/ItemsTest.php
@@ -123,7 +123,8 @@ class ItemsTest extends TestCase
 
         $searchById = route('api.v1.items.index', [
             'size' => 10,
-            'filter[author_id]' => $author1->id,
+            'filter[author]' => 'Věšín, Jaroslav',
+            'filter[authority_id]' => $author1->id,
         ]);
 
         $this->getJson($searchById)->assertJson([

--- a/tests/Models/ItemTest.php
+++ b/tests/Models/ItemTest.php
@@ -176,6 +176,8 @@ class ItemTest extends TestCase
 
         $this->assertEquals('Philips Wouwerman', $data[1]->name);
         $this->assertEquals(null, $data[1]->authority);
+
+        $this->markTestSkipped('should list in the order of the author field');
     }
 
     protected function createFreeItem()

--- a/tests/Models/ItemTest.php
+++ b/tests/Models/ItemTest.php
@@ -175,7 +175,7 @@ class ItemTest extends TestCase
         $this->assertEquals($authority->id, $data[0]->authority->id);
 
         $this->assertEquals('Philips Wouwerman', $data[1]->name);
-        $this->assertFalse(property_exists($data[1], 'authority'));
+        $this->assertEquals(null, $data[1]->authority);
     }
 
     protected function createFreeItem()


### PR DESCRIPTION
# Description

### New `authors` field for `/api/v1/items`
Lists both authors with and without Authority records.
```jsonc
//...
"authors": [
  {
    "name": "Vodrážka, Jaroslav",
    "authority": {
      "id": "11436"
    },
    "name_formatted": "Jaroslav Vodrážka"
  },
  {
    "name": "Viedenský maliar z konca 18. storočia",
    "authority": null,
    "name_formatted": "Viedenský maliar z konca 18. storočia"
  }
]
```
Note that this is currently different from the `authors` field in `/api/v2/items/<id>`
```jsonc
//...
"authors": [
  "Vodrážka, Jaroslav",
  "Viedenský maliar z konca 18. storočia"
]

```

### `/api/v1/items/aggregations` also include a new `authors` term
listing both the author and their Authority ID:

```jsonc
// GET /api/v1/items/aggregations?terms[authors]=authors
{
  "authors": [
    {
      "name": "Vodrážka, Jaroslav",
      "authority": {
        "id": "11436"
      },
      "count": 6
    },
    {
      "name": "Nemecký maliar zo začiatku 19. storočia",
      "authority": null,
      "count": 2
    }
  ]
}
```

This will also list multiple entries for authors with the same name but different authority IDs

###  Search by `author.name` and `author.authority.id` is now supported
When using both, the search is executed as an 'or' query.

### Elasticsearch is upgraded to 7.17.3
In order to enable aggregations by multiple terms

Fixes # (link to Jira or GitHub issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] I have updated the [CHANGELOG](../CHANGELOG.md)
- [x] I have requested at least 1 reviewer for this PR
- [x] I have made corresponding changes to the documentation
