### PR TITLE
Retrieve Authority preview items from DB instead of Elasticsearch

### DIFF
--- a/app/Authority.php
+++ b/app/Authority.php
@@ -8,7 +8,6 @@ use Astrotomic\Translatable\Translatable;
 use Astrotomic\Translatable\Contracts\Translatable as TranslatableContract;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\URL;
@@ -106,6 +105,16 @@ class Authority extends Model implements IndexableModel, TranslatableContract
     public function items()
     {
         return $this->belongsToMany(\App\Item::class);
+    }
+
+    public function previewItems()
+    {
+        return $this->items()
+            ->with('translations')
+            ->orWhere('has_image', true)
+            ->orWhereHas('images')
+            ->orderBy('created_at', 'asc')
+            ->limit(10);
     }
 
     public function record()

--- a/app/Authority.php
+++ b/app/Authority.php
@@ -390,13 +390,9 @@ class Authority extends Model implements IndexableModel, TranslatableContract
         $this->attributes['biography'] = $value ?: '';
     }
 
-    public function incrementViewCount($save = true)
+    public function incrementViewCount()
     {
-        $this->timestamps = false;
-        $this->view_count++;
-        if ($save) {
-            $this->save();
-        }
+        $this->updateQuietly(['view_count' => $this->view_count + 1]);
     }
 
     public function isCorporateBody()

--- a/app/Elasticsearch/Repositories/ItemRepository.php
+++ b/app/Elasticsearch/Repositories/ItemRepository.php
@@ -229,36 +229,6 @@ class ItemRepository extends TranslatableRepository
         return $this->createSearchResult($response);
     }
 
-    public function getPreviewItems(int $size, Authority $authority, string $locale = null): Collection
-    {
-        $response = $this->elasticsearch->search([
-            'index' => $this->getLocalizedIndexName($locale),
-            'body' => [
-                'size' => $size,
-                'query' => [
-                    'bool' => [
-                        'must' => [
-                            ['term' => ['authority_id' => $authority->id]],
-                        ],
-                        'should' => [
-                            ['term' => ['has_image' => true]],
-                            ['term' => ['has_iip' => true]],
-                        ],
-                        'filter' => [
-                            ['term' => ['frontend' => Frontend::get()]],
-                        ],
-                    ],
-                ],
-                'sort' => [
-                    '_score',
-                    ['created_at' => ['order' => 'asc']],
-                ]
-            ],
-        ]);
-
-        return $this->createSearchResult($response)->getCollection();
-    }
-
     public function buildQueryFromFilter(?Filter $filter): ?array
     {
         if (!$filter) {

--- a/app/Http/Controllers/AuthorController.php
+++ b/app/Http/Controllers/AuthorController.php
@@ -69,6 +69,7 @@ class AuthorController extends AbstractSearchRequestController
         // Retrieve from DB with unindexed relationships
         $authorities = Authority::whereIn('id', $authority_ids)
             ->with(['previewItems', 'translations'])
+            ->withCount('items')
             ->orderByRaw('FIELD(id, ' . $authority_ids->join(',') . ')')
             ->paginate($paginator->perPage())
             ->collect();

--- a/app/Http/Controllers/AuthorController.php
+++ b/app/Http/Controllers/AuthorController.php
@@ -66,7 +66,6 @@ class AuthorController extends AbstractSearchRequestController
         $paginator = $data['paginator'];
         $authority_ids = $paginator->getCollection()->pluck('id');
 
-        // Retrieve from DB with unindexed relationships
         $authorities = Authority::whereIn('id', $authority_ids)
             ->with(['previewItems', 'translations'])
             ->withCount('items')


### PR DESCRIPTION
in order to rely less on availability (and writability) of ES.

Author detail page can now be displayed even if ES is down/read-only.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] I have updated the [CHANGELOG](../CHANGELOG.md)
- [x] I have requested at least 1 reviewer for this PR
- [ ] I have made corresponding changes to the documentation
