### PR TITLE
[deploy] fix deploying the tagged release to production

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -29,4 +29,4 @@ jobs:
           private-key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
           known-hosts: ${{ secrets.DEPLOY_SSH_KNOWN_HOSTS }}
           deployer-version: 7.0.0-rc.8
-          dep: deploy production
+          dep: deploy production --tag ${{ github.event.release.tag_name }}


### PR DESCRIPTION
Deployer has been deploying the old `deploy` branch instead of the current tag.

| Date (Europe/Bratislava) | Release      | Author                | Target | Commit                                   |
|--------------------------|--------------|-----------------------|--------|------------------------------------------|
| 2023-12-21 11:19:01      | 48           | ci                    | HEAD   | d506fa7e15a2dd629ef116a75bf3d65085d4728a |
| 2024-01-12 13:20:52      | 49           | ci                    | HEAD   | d506fa7e15a2dd629ef116a75bf3d65085d4728a |
| 2024-03-01 13:06:41      | 50           | ci                    | HEAD   | d506fa7e15a2dd629ef116a75bf3d65085d4728a |

