### PR TITLE
[item] fix cs work type translations

### DIFF
--- a/lang/cs/item.php
+++ b/lang/cs/item.php
@@ -142,10 +142,10 @@ return [
     'untitled' => 'bez názvu',
     'work_types' => [
         'architektúra' => 'architektura',
-        'dizajn' => 'dizajn',
+        'dizajn' => 'design',
         'fotografia' => 'fotografie',
         'fotografia/negatív' => 'fotografie/negativ',
-        'grafický dizajn' => 'grafický dizajn',
+        'grafický dizajn' => 'grafický design',
         'grafika' => 'grafika',
         'iné médiá/video' => 'jiná média/video',
         'kresba' => 'kresba',


### PR DESCRIPTION
Use correct translation of 'design' in Czech.
