### PR TITLE
Simplify index mapping of item authors

### DIFF
--- a/app/Http/Controllers/Api/V1/ItemController.php
+++ b/app/Http/Controllers/Api/V1/ItemController.php
@@ -128,10 +128,10 @@ class ItemController extends Controller
                             'multi_terms' => [
                                 'terms' => [
                                     [
-                                        'field' => 'authors.name.keyword',
+                                        'field' => 'authors.name',
                                     ],
                                     [
-                                        'field' => 'authors.authority.id.keyword',
+                                        'field' => 'authors.authority.id',
                                         'missing' => '',
                                     ],
                                 ],
@@ -318,8 +318,8 @@ class ItemController extends Controller
                 $authorsBuilder ??= Query::bool();
                 $authorsBuilder->should(
                     is_array($value)
-                        ? ['terms' => ["$field.keyword" => $value]]
-                        : ['term' => ["$field.keyword" => $value]]
+                        ? ['terms' => [$field => $value]]
+                        : ['term' => [$field => $value]]
                 );
                 continue;
             }

--- a/config/elasticsearch/mapping/items.php
+++ b/config/elasticsearch/mapping/items.php
@@ -22,6 +22,18 @@ $mapping = [
         ],
         'authors' => [
             'type' => 'nested',
+            'properties' => [
+                'name' => [
+                    'type' => 'keyword',
+                ],
+                'authority' => [
+                    'properties' => [
+                        'id' => [
+                            'type' => 'keyword',
+                        ],
+                    ],
+                ],
+            ],
         ],
         'authority_id' => [
             'type' => 'keyword',


### PR DESCRIPTION
Map all fields as keywords


Old mapping:
```jsonc
{
  "name": [ // text
    "Hora, František"
  ],
  "name.keyword": [
    "Hora, František"
  ],
  "authority.id.keyword": [
    "1717335"
  ],
  "authority.id": [ // text
    "1717335"
  ]
}
```

New mapping
```jsonc
{
  "name": [ // keyword
    "Hora, František"
  ],
  "authority.id": [ //keyword
    "1717335"
  ]
}
```


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] I have updated the [CHANGELOG](../CHANGELOG.md)
- [ ] I have requested at least 1 reviewer for this PR
- [ ] I have made corresponding changes to the documentation
