### PR TITLE
[item] publish work/object type trees to detail

### DIFF
--- a/app/Http/Controllers/Api/V1/ItemController.php
+++ b/app/Http/Controllers/Api/V1/ItemController.php
@@ -249,6 +249,8 @@ class ItemController extends Controller
                     'state_edition',
                     'inscription',
                     'acquisition_date',
+                    'work_type_tree',
+                    'object_type_tree',
                 ]),
             ],
         ];

--- a/app/Item.php
+++ b/app/Item.php
@@ -485,12 +485,12 @@ class Item extends Model implements IndexableModel, TranslatableContract
         return $formated;
     }
 
-    public function getWorkTypesAttribute()
+    public function getWorkTypeTreeAttribute()
     {
         return $this->unserializeTrees($this->work_type);
     }
 
-    public function getObjectTypesAttribute()
+    public function getObjectTypeTreeAttribute()
     {
         return $this->unserializeTrees($this->object_type);
     }

--- a/resources/views/dielo.blade.php
+++ b/resources/views/dielo.blade.php
@@ -144,7 +144,7 @@
                                 <tr>
                                     <td class="atribut">{{ trans('dielo.item_attr_work_type') }}:</td>
                                     <td>
-                                        @foreach ($item->work_types as $stack)
+                                        @foreach ($item->work_type_tree as $stack)
                                             @foreach ($stack as $work_type)
                                                 <a href="{{ route('frontend.catalog.index', ['work_type' => $work_type['path']]) }}"><span itemprop="artform">{{ $work_type['name'] }}</span></a>
                                                 @if (!$loop->last)
@@ -162,7 +162,7 @@
                                 <tr>
                                     <td class="atribut">{{ trans('dielo.item_attr_object_type') }}:</td>
                                     <td>
-                                        @foreach ($item->object_types as $stack)
+                                        @foreach ($item->object_type_tree as $stack)
                                             @foreach ($stack as $object_type)
                                                 <a href="{{ route('frontend.catalog.index', ['object_type' => $object_type['path']]) }}">{{ $object_type['name'] }}</a>
                                                 @if (!$loop->last)

--- a/routes/web.php
+++ b/routes/web.php
@@ -283,7 +283,7 @@ function()
         $gtm_data_layer = [
             'artwork' => [
                 'authors' => array_values($item->authors),
-                'work_types' => collect($item->work_types)->pluck(['path']),
+                'work_types' => collect($item->work_type_tree)->pluck(['path']),
                 'topic ' => $item->topic,
                 'media' => $item->mediums,
                 'technique' => $item->technique,

--- a/tests/Feature/Api/V1/ItemsTest.php
+++ b/tests/Feature/Api/V1/ItemsTest.php
@@ -284,4 +284,46 @@ class ItemsTest extends TestCase
             ],
         ]);
     }
+
+    public function test_show()
+    {
+        $item = Item::factory()->create([
+            'work_type' => 'grafika, voľná',
+            'object_type' => 'tlač, veľký formát',
+        ]);
+        app(ItemRepository::class)->refreshIndex();
+
+        $url = route('api.v1.items.show', ['id' => $item->id]);
+
+        $response = $this->getJson($url);
+        $response->assertJson([
+            'id' => $item->id,
+            'content' => [
+                'work_type_tree' => [
+                    [
+                        [
+                            'name' => 'grafika',
+                            'path' => 'grafika',
+                        ],
+                        [
+                            'name' => 'voľná',
+                            'path' => 'grafika/voľná',
+                        ],
+                    ],
+                ],
+                'object_type_tree' => [
+                    [
+                        [
+                            'name' => 'tlač',
+                            'path' => 'tlač',
+                        ],
+                        [
+                            'name' => 'veľký formát',
+                            'path' => 'tlač/veľký formát',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
 }

--- a/tests/Models/ItemTest.php
+++ b/tests/Models/ItemTest.php
@@ -108,7 +108,7 @@ class ItemTest extends TestCase
         $item = Item::factory()->make([
             'work_type' => 'kresba, prípravná, návrh; iné médiá, album',
         ]);
-        $workTypes = $item->work_types;
+        $workTypes = $item->work_type_tree;
         $this->assertEquals(
             [
                 [


### PR DESCRIPTION
https://jira.sng.sk/browse/MG-75

Currently there's a mismatch of delimiters. Originally, the commas (e. g. `grafika, voľná`) were transformed to slashes (`grafika/voľná`) because the tree analyser in Elasticsearch allows only single-character delimiter. I suggest to convert all values in database to slash-delimtited format and adjust importers accordingly (some already use slashes).