### PR TITLE
Mg 53 fix item filter

### DIFF
--- a/app/Collection.php
+++ b/app/Collection.php
@@ -148,10 +148,7 @@ class Collection extends Model implements TranslatableContract
 
         if (str($url['host'])->contains('sbirky.moravska-galerie.cz')) {
             $filter = collect($query)->map(
-                fn($value, $attribute) => str($value)->whenContains(
-                    '|',
-                    fn(Stringable $value) => $value->explode('|')
-                )
+                fn($value, $attribute) => str($value)->contains('|') ? explode('|', $value) : $value
             );
             return $filter->toArray();
         }

--- a/app/Http/Controllers/Api/V1/ItemController.php
+++ b/app/Http/Controllers/Api/V1/ItemController.php
@@ -84,6 +84,7 @@ class ItemController extends Controller
 
         $response = $searchRequest
             ->paginate($size)
+            ->withQueryString()
             ->onlyDocuments()
             ->toArray();
 

--- a/tests/Feature/Api/CollectionItemsTest.php
+++ b/tests/Feature/Api/CollectionItemsTest.php
@@ -14,21 +14,39 @@ class CollectionItemsTest extends TestCase
     use RefreshDatabase;
     use RecreateSearchIndex;
 
-    public function testIndex()
+    public function testIndexWebumeniaUrl()
     {
-        Item::factory()->create(['author' => 'author-1']);
+        Item::factory(2)->create(['author' => 'author-1']);
         Item::factory()->create(['author' => 'author-2']);
         app(ItemRepository::class)->refreshIndex();
 
         $collection = Collection::factory()->create([
-            'url' => 'https://www.webumenia.sk/katalog-new?filter[author][]=author-1',
+            'url' => 'https://www.webumenia.sk/katalog-new?filter[author]=author-1',
         ]);
 
         $url = route('api.collections.items.index', [
             'collection' => $collection,
-            'size' => 2,
+            'size' => 3,
         ]);
         $response = $this->get($url);
-        $response->assertJsonCount(1, 'data');
+        $response->assertJsonCount(2, 'data');
+    }
+
+    public function testIndexMoravskaGalerieUrl()
+    {
+        Item::factory(2)->create(['author' => 'author-1']);
+        Item::factory()->create(['author' => 'author-2']);
+        app(ItemRepository::class)->refreshIndex();
+
+        $collection = Collection::factory()->create([
+            'url' => 'https://sbirky.moravska-galerie.cz/?author=author-1',
+        ]);
+
+        $url = route('api.collections.items.index', [
+            'collection' => $collection,
+            'size' => 3,
+        ]);
+        $response = $this->get($url);
+        $response->assertJsonCount(2, 'data');
     }
 }


### PR DESCRIPTION
`Stringable` in `item_filter` was ignored when creating `api.v1.items.index` URL