### PR TITLE
Webumenia 2107 new catalog as default

### DIFF
--- a/app/Http/Middleware/RedirectLegacyCatalogRequest.php
+++ b/app/Http/Middleware/RedirectLegacyCatalogRequest.php
@@ -42,9 +42,6 @@ class RedirectLegacyCatalogRequest
      */
     public function handle(Request $request, Closure $next): Response
     {
-        if (!Experiment::is('new-catalog')) {
-            return $next($request);
-        }
 
         if ($request->getQueryString() === null || !$this->isLegacyCatalogRequest($request)) {
             return $next($request);

--- a/app/Http/Middleware/SetExperiments.php
+++ b/app/Http/Middleware/SetExperiments.php
@@ -19,9 +19,9 @@ class SetExperiments
     public function handle(Request $request, Closure $next): Response
     {
         $request->whenFilled('experiment', function ($experiment) {
-            if ($experiment === 'new-catalog' || $experiment === 'new-katalog') {
-                return Experiment::set('new-catalog');
-            }
+            // if ($experiment === 'new-catalog' || $experiment === 'new-katalog') {
+            //     return Experiment::set('new-catalog');
+            // }
         });
 
         return $next($request);

--- a/resources/views/components/searchbar.blade.php
+++ b/resources/views/components/searchbar.blade.php
@@ -4,10 +4,7 @@
     'class' => 'navbar-form right-inner-addon ukraine',
 ]) !!}
 <i class="fa fa-search"></i>
-@php
-$search_value = Experiment::is('new-catalog') ? request()->get('q') : request()->get('search') 
-@endphp
-{!! Form::text('search', $search_value, [
+{!! Form::text('search', request()->get('q'), [
     'class' => 'form-control',
     'placeholder' => utrans('master.search_placeholder'),
     'id' => 'search',

--- a/resources/views/frontend/catalog/index.blade.php
+++ b/resources/views/frontend/catalog/index.blade.php
@@ -10,6 +10,10 @@
     @include('includes.pagination_links', ['paginator' => $paginator])
 @stop
 
+@section('og')
+    <meta name="robots" content="noindex, nofollow">
+@stop
+
 @section('content')
 
     @formStart($form, ['attr' => ['class' => 'js-filter-form filter-form']])

--- a/routes/web.php
+++ b/routes/web.php
@@ -299,8 +299,6 @@ function()
     Route::get('katalog-old', [CatalogController::class, 'getIndex'])
         ->name('frontend.catalog.old');
         
-    // Route::resource('katalog-new', NewCatalogController::class)->names('frontend.catalog-new'); // TODO remove after release
-
     Route::get('katalog/suggestions', [CatalogController::class, 'getSuggestions'])->name('frontend.catalog.suggestions');
     Route::get('katalog/random', [CatalogController::class, 'getRandom'])->name('frontend.catalog.random');
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -292,17 +292,14 @@ function()
 
     Route::get('patternlib', [PatternlibController::class, 'getIndex'])->name('frontend.patternlib.index');
 
-    Route::get('katalog', function (HttpRequest $request) {
-        if (Experiment::is('new-catalog')) {
-            return app(NewCatalogController::class)->index($request);
-        }
-
-        return app(CatalogController::class)->getIndex();
-    })
+    Route::get('katalog', [NewCatalogController::class, 'index'])
         ->middleware(RedirectLegacyCatalogRequest::class)
         ->name('frontend.catalog.index');
         
-    Route::resource('katalog-new', NewCatalogController::class)->names('frontend.catalog-new'); // TODO remove after release
+    Route::get('katalog-old', [CatalogController::class, 'getIndex'])
+        ->name('frontend.catalog.old');
+        
+    // Route::resource('katalog-new', NewCatalogController::class)->names('frontend.catalog-new'); // TODO remove after release
 
     Route::get('katalog/suggestions', [CatalogController::class, 'getSuggestions'])->name('frontend.catalog.suggestions');
     Route::get('katalog/random', [CatalogController::class, 'getRandom'])->name('frontend.catalog.random');

--- a/tests/Feature/RedirectLegacyCatalogRequestTest.php
+++ b/tests/Feature/RedirectLegacyCatalogRequestTest.php
@@ -7,12 +7,6 @@ use Tests\TestCase;
 
 class RedirectLegacyCatalogRequestTest extends TestCase
 {
-    public function setUp(): void
-    {
-        parent::setUp();
-
-        Experiment::set('new-catalog');
-    }
 
     public function test_redirects_to_new_catalog_url(): void
     {

--- a/tests/Feature/SearchTest.php
+++ b/tests/Feature/SearchTest.php
@@ -12,6 +12,6 @@ class SearchTest extends TestCase
     public function testPageNumberTooLargeDoesNotProduceError()
     {
         $response = $this->get('/katalog?page=99999');
-        $response->assertStatus(200);
+        $response->assertStatus(302); // Should be redirected by the RedirectLegacyCatalogRequest middleware
     }
 }

--- a/tests/NewCatalogTest.php
+++ b/tests/NewCatalogTest.php
@@ -2,17 +2,10 @@
 
 namespace Tests\Views\Frontend;
 
-use App\Facades\Experiment;
 use Tests\TestCase;
 
 class NewCatalogTest extends TestCase
 {
-    public function setUp(): void
-    {
-        parent::setUp();
-
-        Experiment::set('new-catalog');
-    }
 
     public function test_title_is_based_on_filters()
     {

--- a/tests/Views/Frontend/CatalogViewTest.php
+++ b/tests/Views/Frontend/CatalogViewTest.php
@@ -10,17 +10,11 @@ class CatalogViewTest extends TestCase
 {
     public function testGetIndex()
     {
-        $itemRepositoryMock = $this->createMock(ItemRepository::class);
-        $itemRepositoryMock->expects($this->any())
-            ->method('listValues')
-            ->willReturn(collect());
-        $itemRepositoryMock->expects($this->once())
-            ->method('search')
-            ->willReturn(new SearchResult(collect(), 0));
-        $this->app->instance(ItemRepository::class, $itemRepositoryMock);
-
         $response = $this->get('/katalog');
+
         $response->assertStatus(200);
+        $response->assertViewIs('frontend.catalog-new.index');
+        $response->assertViewHas('title');
     }
 
     public function testGetSuggestions()
@@ -54,7 +48,8 @@ class CatalogViewTest extends TestCase
     }
 
     // test the legacy catalog - should be removed after no longer needed/supported
-    public function testOldCatalog() {
+    public function testOldCatalog()
+    {
         $response = $this->get('/katalog-old');
         $response->assertStatus(200);
     }

--- a/tests/Views/Frontend/CatalogViewTest.php
+++ b/tests/Views/Frontend/CatalogViewTest.php
@@ -52,4 +52,10 @@ class CatalogViewTest extends TestCase
         $response = $this->get('/katalog/random');
         $response->assertStatus(200);
     }
+
+    // test the legacy catalog - should be removed after no longer needed/supported
+    public function testOldCatalog() {
+        $response = $this->get('/katalog-old');
+        $response->assertStatus(200);
+    }
 }


### PR DESCRIPTION
# Description

Makes new catalog the default one. 
Keeps the legacy one available on the route `/katalog-old`

Fixes [WEBUMENIA-2107](https://jira.sng.sk/browse/WEBUMENIA-2107)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] I have updated the [CHANGELOG](../CHANGELOG.md)
- [x] I have requested at least 1 reviewer for this PR
- [ ] I have made corresponding changes to the documentation
